### PR TITLE
Misc fixes

### DIFF
--- a/src/webapp/__tests__/__snapshots__/webapp.test.ts.snap
+++ b/src/webapp/__tests__/__snapshots__/webapp.test.ts.snap
@@ -235,7 +235,7 @@ Object {
                 "EventType": "viewer-response",
                 "FunctionARN": Object {
                   "Fn::GetAtt": Array [
-                    "WebappSecurityHeadersSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b55767823ADB781",
+                    "WebappSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b5576786884CD5C",
                     "FunctionARN",
                   ],
                 },
@@ -286,7 +286,7 @@ Object {
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
     },
-    "WebappSecurityHeadersSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b55767823ADB781": Object {
+    "WebappSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b5576786884CD5C": Object {
       "Properties": Object {
         "AutoPublish": true,
         "FunctionCode": "function handler(event) {
@@ -301,10 +301,10 @@ Object {
       return response;
     }",
         "FunctionConfig": Object {
-          "Comment": "SecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b557678",
+          "Comment": "Functionc85c32e0a9f633a8edb409ebc4166047306b557678",
           "Runtime": "cloudfront-js-1.0",
         },
-        "Name": "SecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b557678",
+        "Name": "Functionc85c32e0a9f633a8edb409ebc4166047306b557678",
       },
       "Type": "AWS::CloudFront::Function",
     },

--- a/src/webapp/__tests__/__snapshots__/webapp.test.ts.snap
+++ b/src/webapp/__tests__/__snapshots__/webapp.test.ts.snap
@@ -235,7 +235,7 @@ Object {
                 "EventType": "viewer-response",
                 "FunctionARN": Object {
                   "Fn::GetAtt": Array [
-                    "WebappSecurityHeadersFunctionC3DFAD73",
+                    "WebappSecurityHeadersSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b55767823ADB781",
                     "FunctionARN",
                   ],
                 },
@@ -286,7 +286,7 @@ Object {
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
     },
-    "WebappSecurityHeadersFunctionC3DFAD73": Object {
+    "WebappSecurityHeadersSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b55767823ADB781": Object {
       "Properties": Object {
         "AutoPublish": true,
         "FunctionCode": "function handler(event) {
@@ -301,30 +301,10 @@ Object {
       return response;
     }",
         "FunctionConfig": Object {
-          "Comment": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                "StackWebappSecurityHeadersFunction5A01FE7A",
-              ],
-            ],
-          },
+          "Comment": "SecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b557678",
           "Runtime": "cloudfront-js-1.0",
         },
-        "Name": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "StackWebappSecurityHeadersFunction5A01FE7A",
-            ],
-          ],
-        },
+        "Name": "SecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b557678",
       },
       "Type": "AWS::CloudFront::Function",
     },

--- a/src/webapp/__tests__/webapp.test.ts
+++ b/src/webapp/__tests__/webapp.test.ts
@@ -1,7 +1,7 @@
 import "@aws-cdk/assert/jest"
 import { App, Stack } from "@aws-cdk/core"
 import "jest-cdk-snapshot"
-import { Webapp } from ".."
+import { Webapp } from "../"
 
 test("create webapp with default parameters", () => {
   const app = new App()

--- a/src/webapp/security-headers.ts
+++ b/src/webapp/security-headers.ts
@@ -65,20 +65,20 @@ function generateContentSecurityPolicyHeader(
   headerOptions?: ContentSecurityPolicyHeader,
 ) {
   const defaultValues = {
-    baseUri: "self",
-    childSrc: "none",
-    connectSrc: "self",
-    defaultSrc: "self",
-    fontSrc: "self",
-    formAction: "self",
-    frameAncestors: "none",
-    frameSrc: "self",
-    imgSrc: "self",
-    manifestSrc: "self",
-    mediaSrc: "self",
-    objectSrc: "none",
-    scriptSrc: "self",
-    styleSrc: "self",
+    baseUri: "'self'",
+    childSrc: "'none'",
+    connectSrc: "'self'",
+    defaultSrc: "'self'",
+    fontSrc: "'self'",
+    formAction: "'self'",
+    frameAncestors: "'none'",
+    frameSrc: "'self'",
+    imgSrc: "'self'",
+    manifestSrc: "'self'",
+    mediaSrc: "'self'",
+    objectSrc: "'none'",
+    scriptSrc: "'self'",
+    styleSrc: "'self'",
   }
 
   const options = {
@@ -91,18 +91,18 @@ function generateContentSecurityPolicyHeader(
   )
 
   let headerValue = ""
-  headerValue += `base-uri '${trim(trim(options.baseUri))}';`
-  headerValue += `child-src '${trim(options.childSrc)}';`
-  headerValue += `connect-src '${trim(options.connectSrc)}';`
-  headerValue += `default-src '${trim(options.defaultSrc)}';`
-  headerValue += `font-src '${trim(options.fontSrc)}';`
-  headerValue += `frame-src '${trim(options.frameSrc)}';`
-  headerValue += `img-src '${trim(options.imgSrc)}';`
-  headerValue += `manifest-src '${trim(options.manifestSrc)}';`
-  headerValue += `media-src '${trim(options.mediaSrc)}';`
-  headerValue += `object-src '${trim(options.objectSrc)}';`
-  headerValue += `script-src '${trim(options.scriptSrc)}';`
-  headerValue += `style-src '${trim(options.styleSrc)}';`
+  headerValue += `base-uri ${trim(options.baseUri)};`
+  headerValue += `child-src ${trim(options.childSrc)};`
+  headerValue += `connect-src ${trim(options.connectSrc)};`
+  headerValue += `default-src ${trim(options.defaultSrc)};`
+  headerValue += `font-src ${trim(options.fontSrc)};`
+  headerValue += `frame-src ${trim(options.frameSrc)};`
+  headerValue += `img-src ${trim(options.imgSrc)};`
+  headerValue += `manifest-src ${trim(options.manifestSrc)};`
+  headerValue += `media-src ${trim(options.mediaSrc)};`
+  headerValue += `object-src ${trim(options.objectSrc)};`
+  headerValue += `script-src ${trim(options.scriptSrc)};`
+  headerValue += `style-src ${trim(options.styleSrc)};`
 
   return trim(headerValue)
 }

--- a/src/webapp/security-headers.ts
+++ b/src/webapp/security-headers.ts
@@ -180,7 +180,7 @@ export class WebappSecurityHeaders extends cdk.Construct {
     }`
 
     // Hardcoded logical ID due to bug: https://github.com/aws/aws-cdk/issues/15523
-    const functionId = `SecurityHeadersFunction${this.node.addr}`
+    const functionId = `Function${this.node.addr}`
 
     this.securityHeadersFunction = new cloudfront.Function(this, functionId, {
       functionName: functionId,

--- a/src/webapp/security-headers.ts
+++ b/src/webapp/security-headers.ts
@@ -179,7 +179,11 @@ export class WebappSecurityHeaders extends cdk.Construct {
       return response;
     }`
 
-    this.securityHeadersFunction = new cloudfront.Function(this, "Function", {
+    // Hardcoded logical ID due to bug: https://github.com/aws/aws-cdk/issues/15523
+    const functionId = `SecurityHeadersFunction${this.node.addr}`
+
+    this.securityHeadersFunction = new cloudfront.Function(this, functionId, {
+      functionName: functionId,
       code: cloudfront.FunctionCode.fromInline(lambdaCode),
     })
   }


### PR DESCRIPTION
- Only wrap the default CSP directives in single quotes, as these contain CSP keywords (`self`, `none`, etc.)
- Fix flaky test due to upstream bug in CDK