### PR TITLE
Remove 'experimental' from readme and package.json description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Liflig CDK
 
-More details to come.
+This is a collection of reusable constructs and patterns for
+CDK setups, for use within Liflig.
 
 ## State of repository and package
 
-This is an early experiment of building reusable constructs and patterns for
-CDK setups, for use within Liflig. We do not expect others to depend on this,
-and as such will not be following semantic versioning strictly. There will be
-breaking changes across both minor and patch releases, as we will be
-coordinating changes internally.
+We do not expect others to depend on this, and as such will not be following semantic versioning strictly.
+There will be breaking changes across both minor and patch releases, as we will be coordinating changes internally.
 
 CDK has some major issues for 3rd party library authors which
 are not yet resolved. Some relevant information:
@@ -30,7 +28,7 @@ are not yet resolved. Some relevant information:
    npm run test -- -u
    ```
 
-   Investigate any changes before commiting.
+   Investigate any changes before committing.
 
 ## Testing library changes before releasing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@liflig/cdk",
   "version": "0.0.0-development",
-  "description": "Experimental CDK library for Liflig",
+  "description": "CDK library for Liflig",
   "repository": {
     "type": "git",
     "url": "https://github.com/capralifecycle/liflig-cdk"


### PR DESCRIPTION
This package is already in production in several systems, and not an experiment any more.