### PR TITLE
Expose ALB Listener Rule internals

### DIFF
--- a/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
+++ b/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
@@ -42,9 +42,11 @@ Object {
         "Conditions": Array [
           Object {
             "Field": "host-header",
-            "Values": Array [
-              "example.com",
-            ],
+            "HostHeaderConfig": Object {
+              "Values": Array [
+                "example.com",
+              ],
+            },
           },
         ],
         "ListenerArn": Object {

--- a/src/ecs/listener-rule.ts
+++ b/src/ecs/listener-rule.ts
@@ -17,15 +17,27 @@ export interface ListenerRuleProps {
 }
 
 export class ListenerRule extends cdk.Construct {
+  /**
+   * The rule created in the ALB Listener.
+   *
+   * Use {@link elb.ApplicationListenerRule.addCondition} to add [other conditions](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#rule-condition-types)
+   * than Host-header.
+   */
+  public readonly applicationListenerRule: elb.ApplicationListenerRule
+
   constructor(scope: cdk.Construct, id: string, props: ListenerRuleProps) {
     super(scope, id)
 
-    new elb.ApplicationListenerRule(this, "ListenerRule", {
-      listener: props.httpsListener,
-      priority: props.listenerPriority,
-      hostHeader: props.domainName,
-      targetGroups: [props.targetGroup],
-    })
+    this.applicationListenerRule = new elb.ApplicationListenerRule(
+      this,
+      "ListenerRule",
+      {
+        listener: props.httpsListener,
+        priority: props.listenerPriority,
+        hostHeader: props.domainName,
+        targetGroups: [props.targetGroup],
+      },
+    )
 
     if (props.hostedZone != null) {
       new route53.ARecord(this, "ARecord", {

--- a/src/ecs/listener-rule.ts
+++ b/src/ecs/listener-rule.ts
@@ -34,7 +34,7 @@ export class ListenerRule extends cdk.Construct {
       {
         listener: props.httpsListener,
         priority: props.listenerPriority,
-        hostHeader: props.domainName,
+        conditions: [elb.ListenerCondition.hostHeaders([props.domainName])],
         targetGroups: [props.targetGroup],
       },
     )


### PR DESCRIPTION
The listener rule may be used to add more conditions, such as custom header matching or path matching.
Also uses the new `conditions` property, which replaced the deprecated `hostHeader` property.