### PR TITLE
Replace deprecated CDK APIs

### DIFF
--- a/__snapshots__/app/cdk-pipeline-cdk-source.template.json
+++ b/__snapshots__/app/cdk-pipeline-cdk-source.template.json
@@ -328,7 +328,7 @@
               "Principal": {
                 "AWS": {
                   "Fn::GetAtt": [
-                    "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleAB5F1F3C",
+                    "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRole5D5FB735",
                     "Arn"
                   ]
                 }
@@ -346,7 +346,7 @@
               "Principal": {
                 "AWS": {
                   "Fn::GetAtt": [
-                    "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleAB5F1F3C",
+                    "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRole5D5FB735",
                     "Arn"
                   ]
                 }
@@ -690,7 +690,7 @@
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRole44331778",
+                  "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRole3EB0ED91",
                   "Arn"
                 ]
               }
@@ -850,7 +850,7 @@
                 },
                 "Configuration": {
                   "ProjectName": {
-                    "Ref": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B"
+                    "Ref": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3"
                   },
                   "EnvironmentVariables": "[{\"name\":\"_PROJECT_CONFIG_HASH\",\"type\":\"PLAINTEXT\",\"value\":\"snapshot-value\"}]"
                 },
@@ -859,22 +859,22 @@
                     "Name": "Artifact_PrepareCdkSource_prepare-cdk-source"
                   }
                 ],
-                "Name": "Synth",
+                "Name": "GenerateCloudAssembly",
                 "OutputArtifacts": [
                   {
-                    "Name": "Artifact_GenerateCloudAssembly_Synth"
+                    "Name": "GenerateCloudAssembly_Output"
                   }
                 ],
                 "RoleArn": {
                   "Fn::GetAtt": [
-                    "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRole44331778",
+                    "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRole3EB0ED91",
                     "Arn"
                   ]
                 },
                 "RunOrder": 1
               }
             ],
-            "Name": "GenerateCloudAssembly"
+            "Name": "Build"
           },
           {
             "Actions": [
@@ -888,11 +888,12 @@
                 "Configuration": {
                   "ProjectName": {
                     "Ref": "PipelineCdkPipelineUpdatePipelineSelfMutation3D8B717E"
-                  }
+                  },
+                  "EnvironmentVariables": "[{\"name\":\"_PROJECT_CONFIG_HASH\",\"type\":\"PLAINTEXT\",\"value\":\"snapshot-value\"}]"
                 },
                 "InputArtifacts": [
                   {
-                    "Name": "Artifact_GenerateCloudAssembly_Synth"
+                    "Name": "GenerateCloudAssembly_Output"
                   }
                 ],
                 "Name": "SelfMutate",
@@ -944,14 +945,14 @@
                   },
                   "ActionMode": "CHANGE_SET_REPLACE",
                   "ChangeSetName": "PipelineChange",
-                  "TemplatePath": "Artifact_GenerateCloudAssembly_Synth::assembly-cdk-pipeline-cdk-source-example/cdkpipelinecdksourceexample06670C59.template.json"
+                  "TemplatePath": "GenerateCloudAssembly_Output::assembly-cdk-pipeline-cdk-source-example/cdkpipelinecdksourceexample06670C59.template.json"
                 },
                 "InputArtifacts": [
                   {
-                    "Name": "Artifact_GenerateCloudAssembly_Synth"
+                    "Name": "GenerateCloudAssembly_Output"
                   }
                 ],
-                "Name": "example.Prepare",
+                "Name": "Prepare",
                 "RoleArn": {
                   "Fn::Join": [
                     "",
@@ -989,7 +990,7 @@
                   "ActionMode": "CHANGE_SET_EXECUTE",
                   "ChangeSetName": "PipelineChange"
                 },
-                "Name": "example.Deploy",
+                "Name": "Deploy",
                 "RoleArn": {
                   "Fn::Join": [
                     "",
@@ -1371,89 +1372,7 @@
         "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/PrepareCdkSource/prepare-cdk-source/CodePipelineActionRole/DefaultPolicy/Resource"
       }
     },
-    "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRole44331778": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition"
-                      },
-                      ":iam::",
-                      {
-                        "Ref": "AWS::AccountId"
-                      },
-                      ":root"
-                    ]
-                  ]
-                }
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "my-project"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-cdk"
-          },
-          {
-            "Key": "StackName",
-            "Value": "cdk-pipeline-cdk-source"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CodePipelineActionRole/Resource"
-      }
-    },
-    "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRoleDefaultPolicyB9E077F7": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B",
-                  "Arn"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRoleDefaultPolicyB9E077F7",
-        "Roles": [
-          {
-            "Ref": "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRole44331778"
-          }
-        ]
-      },
-      "Metadata": {
-        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CodePipelineActionRole/DefaultPolicy/Resource"
-      }
-    },
-    "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleAB5F1F3C": {
+    "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRole5D5FB735": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -1467,27 +1386,13 @@
             }
           ],
           "Version": "2012-10-17"
-        },
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "my-project"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-cdk"
-          },
-          {
-            "Key": "StackName",
-            "Value": "cdk-pipeline-cdk-source"
-          }
-        ]
+        }
       },
       "Metadata": {
-        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CdkBuildProject/Role/Resource"
+        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CdkBuildProject/Role/Resource"
       }
     },
-    "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleDefaultPolicyBBE56835": {
+    "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRoleDefaultPolicy027A12A1": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyDocument": {
@@ -1518,7 +1423,7 @@
                       },
                       ":log-group:/aws/codebuild/",
                       {
-                        "Ref": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B"
+                        "Ref": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3"
                       }
                     ]
                   ]
@@ -1541,7 +1446,7 @@
                       },
                       ":log-group:/aws/codebuild/",
                       {
-                        "Ref": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B"
+                        "Ref": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3"
                       },
                       ":*"
                     ]
@@ -1576,7 +1481,7 @@
                     },
                     ":report-group/",
                     {
-                      "Ref": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B"
+                      "Ref": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3"
                     },
                     "-*"
                   ]
@@ -1650,18 +1555,18 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleDefaultPolicyBBE56835",
+        "PolicyName": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRoleDefaultPolicy027A12A1",
         "Roles": [
           {
-            "Ref": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleAB5F1F3C"
+            "Ref": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRole5D5FB735"
           }
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CdkBuildProject/Role/DefaultPolicy/Resource"
+        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CdkBuildProject/Role/DefaultPolicy/Resource"
       }
     },
-    "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B": {
+    "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3": {
       "Type": "AWS::CodeBuild::Project",
       "Properties": {
         "Artifacts": {
@@ -1669,13 +1574,6 @@
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "NPM_CONFIG_UNSAFE_PERM",
-              "Type": "PLAINTEXT",
-              "Value": "true"
-            }
-          ],
           "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -1683,12 +1581,12 @@
         },
         "ServiceRole": {
           "Fn::GetAtt": [
-            "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleAB5F1F3C",
+            "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRole5D5FB735",
             "Arn"
           ]
         },
         "Source": {
-          "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"pre_build\": {\n      \"commands\": [\n        \"npm ci\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"npx cdk synth\"\n      ]\n    }\n  },\n  \"artifacts\": {\n    \"base-directory\": \"cdk.out\",\n    \"files\": \"**/*\"\n  }\n}",
+          "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"install\": {\n      \"commands\": [\n        \"npm ci\"\n      ]\n    },\n    \"build\": {\n      \"commands\": [\n        \"npx cdk synth\"\n      ]\n    }\n  },\n  \"artifacts\": {\n    \"base-directory\": \"cdk.out\",\n    \"files\": \"**/*\"\n  }\n}",
           "Type": "CODEPIPELINE"
         },
         "EncryptionKey": {
@@ -1696,24 +1594,78 @@
             "PipelineCodePipelineArtifactsBucketEncryptionKey0E77C3AE",
             "Arn"
           ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CdkBuildProject/Resource"
+      }
+    },
+    "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRole3EB0ED91": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":iam::",
+                      {
+                        "Ref": "AWS::AccountId"
+                      },
+                      ":root"
+                    ]
+                  ]
+                }
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CodePipelineActionRole/Resource"
+      }
+    },
+    "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRoleDefaultPolicy49026C91": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3",
+                  "Arn"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
         },
-        "Tags": [
+        "PolicyName": "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRoleDefaultPolicy49026C91",
+        "Roles": [
           {
-            "Key": "Project",
-            "Value": "my-project"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-cdk"
-          },
-          {
-            "Key": "StackName",
-            "Value": "cdk-pipeline-cdk-source"
+            "Ref": "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRole3EB0ED91"
           }
         ]
       },
       "Metadata": {
-        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CdkBuildProject/Resource"
+        "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CodePipelineActionRole/DefaultPolicy/Resource"
       }
     },
     "PipelineCodePipelineUpdatePipelineSelfMutateCodePipelineActionRole16D29A61": {
@@ -1745,21 +1697,7 @@
             }
           ],
           "Version": "2012-10-17"
-        },
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "my-project"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-cdk"
-          },
-          {
-            "Key": "StackName",
-            "Value": "cdk-pipeline-cdk-source"
-          }
-        ]
+        }
       },
       "Metadata": {
         "aws:cdk:path": "cdk-pipeline-cdk-source/Pipeline/CodePipeline/UpdatePipeline/SelfMutate/CodePipelineActionRole/Resource"

--- a/__snapshots__/app/cdk-pipeline-cloud-assembly.template.json
+++ b/__snapshots__/app/cdk-pipeline-cloud-assembly.template.json
@@ -778,7 +778,8 @@
                 "Configuration": {
                   "ProjectName": {
                     "Ref": "PipelineCdkPipelineUpdatePipelineSelfMutation3D8B717E"
-                  }
+                  },
+                  "EnvironmentVariables": "[{\"name\":\"_PROJECT_CONFIG_HASH\",\"type\":\"PLAINTEXT\",\"value\":\"snapshot-value\"}]"
                 },
                 "InputArtifacts": [
                   {
@@ -841,7 +842,7 @@
                     "Name": "Artifact_PrepareCloudAssembly_cloud-assembly-lookup"
                   }
                 ],
-                "Name": "example.Prepare",
+                "Name": "Prepare",
                 "RoleArn": {
                   "Fn::Join": [
                     "",
@@ -879,7 +880,7 @@
                   "ActionMode": "CHANGE_SET_EXECUTE",
                   "ChangeSetName": "PipelineChange"
                 },
-                "Name": "example.Deploy",
+                "Name": "Deploy",
                 "RoleArn": {
                   "Fn::Join": [
                     "",
@@ -1290,21 +1291,7 @@
             }
           ],
           "Version": "2012-10-17"
-        },
-        "Tags": [
-          {
-            "Key": "Project",
-            "Value": "my-project"
-          },
-          {
-            "Key": "SourceRepo",
-            "Value": "github/capralifecycle/liflig-cdk"
-          },
-          {
-            "Key": "StackName",
-            "Value": "cdk-pipeline-cloud-assembly"
-          }
-        ]
+        }
       },
       "Metadata": {
         "aws:cdk:path": "cdk-pipeline-cloud-assembly/Pipeline/CodePipeline/UpdatePipeline/SelfMutate/CodePipelineActionRole/Resource"

--- a/__snapshots__/app/manifest.json
+++ b/__snapshots__/app/manifest.json
@@ -1121,34 +1121,34 @@
             "data": "PipelineCodePipelinePrepareCdkSourcepreparecdksourceCodePipelineActionRoleDefaultPolicyC1327038"
           }
         ],
-        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CodePipelineActionRole/Resource": [
+        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CdkBuildProject/Role/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRole44331778"
+            "data": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRole5D5FB735"
           }
         ],
-        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CodePipelineActionRole/DefaultPolicy/Resource": [
+        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CdkBuildProject/Role/DefaultPolicy/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "PipelineCodePipelineGenerateCloudAssemblySynthCodePipelineActionRoleDefaultPolicyB9E077F7"
+            "data": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProjectRoleDefaultPolicy027A12A1"
           }
         ],
-        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CdkBuildProject/Role/Resource": [
+        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CdkBuildProject/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleAB5F1F3C"
+            "data": "PipelineCodePipelineBuildGenerateCloudAssemblyCdkBuildProject45DF9DF3"
           }
         ],
-        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CdkBuildProject/Role/DefaultPolicy/Resource": [
+        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CodePipelineActionRole/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectRoleDefaultPolicyBBE56835"
+            "data": "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRole3EB0ED91"
           }
         ],
-        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/GenerateCloudAssembly/Synth/CdkBuildProject/Resource": [
+        "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/Build/GenerateCloudAssembly/CodePipelineActionRole/DefaultPolicy/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "PipelineCodePipelineGenerateCloudAssemblySynthCdkBuildProjectCBC06C6B"
+            "data": "PipelineCodePipelineBuildGenerateCloudAssemblyCodePipelineActionRoleDefaultPolicy49026C91"
           }
         ],
         "/cdk-pipeline-cdk-source/Pipeline/CodePipeline/UpdatePipeline/SelfMutate/CodePipelineActionRole/Resource": [

--- a/examples/cdk-pipelines.ts
+++ b/examples/cdk-pipelines.ts
@@ -35,7 +35,7 @@ export class LifligCdkPipelineCdkSourceStack extends Stack {
       sourceType: "cdk-source",
     })
 
-    pipeline.cdkPipeline.addApplicationStage(new ExampleStage(this, "example"))
+    pipeline.cdkPipeline.addStage(new ExampleStage(this, "example"))
   }
 }
 
@@ -48,6 +48,6 @@ export class LifligCdkPipelineCloudAssemblyStack extends Stack {
       sourceType: "cloud-assembly",
     })
 
-    pipeline.cdkPipeline.addApplicationStage(new ExampleStage(this, "example"))
+    pipeline.cdkPipeline.addStage(new ExampleStage(this, "example"))
   }
 }

--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -87,7 +87,7 @@ export class ServiceAlarms extends cdk.Construct {
       namespace: "AWS/ApplicationELB",
       statistic: "Average",
       period: cdk.Duration.seconds(60),
-      dimensions: {
+      dimensionsMap: {
         TargetGroup: props.targetGroupFullName,
         LoadBalancer: props.loadBalancerFullName,
       },
@@ -108,7 +108,7 @@ export class ServiceAlarms extends cdk.Construct {
       namespace: "AWS/ApplicationELB",
       statistic: "Sum",
       period: cdk.Duration.seconds(60),
-      dimensions: {
+      dimensionsMap: {
         TargetGroup: props.targetGroupFullName,
         LoadBalancer: props.loadBalancerFullName,
       },

--- a/src/cdk-pipelines/__tests__/slack-notification.test.ts
+++ b/src/cdk-pipelines/__tests__/slack-notification.test.ts
@@ -22,7 +22,7 @@ test("slack-notification", () => {
     sourceType: "cloud-assembly",
   })
 
-  pipeline.cdkPipeline.addApplicationStage(stage)
+  pipeline.cdkPipeline.addStage(stage)
 
   pipeline.addSlackNotification({
     slackWebhookUrl: "https://hooks.slack.com/services/abc",

--- a/src/ecs/fargate-service.ts
+++ b/src/ecs/fargate-service.ts
@@ -123,7 +123,7 @@ export class FargateService extends cdk.Construct {
       healthCheckGracePeriod: props.healthCheckGracePeriod,
       desiredCount: props.desiredCount,
       assignPublicIp: true,
-      securityGroup: this.securityGroup,
+      securityGroups: [this.securityGroup],
       platformVersion: ecs.FargatePlatformVersion.VERSION1_4,
       enableExecuteCommand: true,
       ...props.overrideFargateServiceProps,


### PR DESCRIPTION
Replace deprecated CDK APIs in preparation of upgrading from CDK v1 to v2.

- Replace deprecated properties used in various constructs
- Replace "old" CDK Pipelines API with the new one
  - Besides updating snapshots, library consumers that use Liflig CDK Pipelines will need to make small adjustments to their CDK codebase, mainly changing `pipeline.addApplicationStage(...)` to `pipeline.addStage(...)`.
  - (The biggest change for us as library maintainers is that we now need to pass in a `synth` property when creating the pipeline. This property basically needs to resolve to an artifact that contains the cloud assembly. The changes introduced in this PR shoehorns the necessary changes into the existing code structure, so there are probably  cleaner ways to do this. But we should be able to defer a potential refactor to a later PR without causing any diff in the snapshots)
  - Some tags are unexpectedly removed from various CDK Pipelines-related resources (e.g., IAM roles using by CodePipeline) when upgrading to the new CDK Pipelines API. Seems like the aspect we've set up for tagging is not being applied to all constructs, and it is not clear to me why this is happening. It's not a big deal if it only affects these a handful of pipeline-related roles, but this is unexpected behavior that I'd like to get to the bottom of. In general, we should be able to trust that an aspect visits all constructs in a given stack. I've created an issue https://github.com/aws/aws-cdk/issues/18440.

I'm leaning towards merging these changes to an `alpha` branch. On this branch, the release plugin will then automatically publish releases such as `1.5.3-alpha.1`, etc. This makes it easy for consumers of the library to test out the changes before we merge it into master and a stable release. (And we can re-use the branch for the CDK v2 updates -- e.g., `2.0.0-alpha.1` etc.)