### PR TITLE
Default lifecycle rules for ECR repository

### DIFF
--- a/__snapshots__/app/build-artifacts.template.json
+++ b/__snapshots__/app/build-artifacts.template.json
@@ -244,6 +244,9 @@
     "BuildArtifactsEcrRepository58C90D9A": {
       "Type": "AWS::ECR::Repository",
       "Properties": {
+        "LifecyclePolicy": {
+          "LifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"selection\":{\"tagStatus\":\"any\",\"countType\":\"sinceImagePushed\",\"countNumber\":180,\"countUnit\":\"days\"},\"action\":{\"type\":\"expire\"}}]}"
+        },
         "RepositoryName": "some-ecr-repo-name",
         "RepositoryPolicyText": {
           "Statement": [

--- a/src/build-artifacts/index.ts
+++ b/src/build-artifacts/index.ts
@@ -18,6 +18,12 @@ interface Props {
    */
   ecrRepositoryName: string
   /**
+   * The lifecycle rules to apply to images stored in the ECR repository.
+   *
+   * @default - Expire images after 180 days
+   */
+  ecrRepositoryLifecycleRules?: ecr.LifecycleRule[]
+  /**
    * Reference to the IAM Role that will be granted permission to
    * assume the CI role. This role must have permission to assume
    * the CI role.
@@ -121,6 +127,12 @@ export class BuildArtifacts extends constructs.Construct {
 
     const ecrRepo = new ecr.Repository(this, "EcrRepository", {
       repositoryName: ecrRepositoryName,
+      lifecycleRules: props.ecrRepositoryLifecycleRules || [
+        {
+          maxImageAge: cdk.Duration.days(180),
+          tagStatus: ecr.TagStatus.ANY,
+        },
+      ],
     })
 
     if (ciRole) {


### PR DESCRIPTION
Configures a default lifecycle rule that expires images after 180 days.