### PR TITLE
Fix: use unique construct id for slack notification Event listener

### DIFF
--- a/src/cdk-pipelines/__tests__/slack-notification.test.ts
+++ b/src/cdk-pipelines/__tests__/slack-notification.test.ts
@@ -1,6 +1,7 @@
 import "@aws-cdk/assert/jest"
 import { App, CfnOutput, Stack, Stage } from "aws-cdk-lib"
 import { LifligCdkPipeline } from "../liflig-cdk-pipeline"
+import { SlackNotification } from "../slack-notification"
 
 test("slack-notification", () => {
   const app = new App({
@@ -27,6 +28,13 @@ test("slack-notification", () => {
   pipeline.addSlackNotification({
     slackWebhookUrl: "https://hooks.slack.com/services/abc",
     slackChannel: "#test",
+  })
+
+  new SlackNotification(pipelineStack, "ExtraSlackNotification", {
+    pipeline: pipeline.codePipeline,
+    slackWebhookUrl: "https://hooks.slack.com/services/abc",
+    slackChannel: "#test-other",
+    singletonLambdaUuid: "f0d7e25c-8247-48bb-beb4-5b1d8ff91f30",
   })
 
   expect(pipelineStack).toHaveResourceLike("AWS::Events::Rule", {

--- a/src/cdk-pipelines/slack-notification.ts
+++ b/src/cdk-pipelines/slack-notification.ts
@@ -93,7 +93,7 @@ export class SlackNotification extends constructs.Construct {
       }),
     )
 
-    props.pipeline.onStateChange("Event", {
+    props.pipeline.onStateChange("Event" + (props.singletonLambdaUuid ?? ""), {
       eventPattern: {
         detail: {
           // Available states: https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html


### PR DESCRIPTION
The 'Event' passed to 'onStateChange' is used as a construct id.
By appending the lambda uuid, this will not collide with the default construct id
from 'addSlackNotification'.