### PR TITLE
feat(alarms): add option to disable OK action

### DIFF
--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -39,6 +39,9 @@ export class ServiceAlarms extends constructs.Construct {
   addJsonErrorAlarm(props: {
     logGroup: logs.ILogGroup
     alarmDescription?: string
+    /** Set to `false` to stop the alarm from sending OK events.
+     * @default true */
+    enableOkAction?: boolean
   }): void {
     const errorMetricFilter = props.logGroup.addMetricFilter(
       "ErrorMetricFilter",
@@ -77,7 +80,9 @@ export class ServiceAlarms extends constructs.Construct {
       })
 
     errorAlarm.addAlarmAction(this.action)
-    errorAlarm.addOkAction(this.action)
+    if (props.enableOkAction ?? true) {
+      errorAlarm.addOkAction(this.action)
+    }
   }
 
   /**


### PR DESCRIPTION
It doesn't mean much with an OK action on an error log with evaluation period 1.
You only double the amount of messages.
The fact that the system stopped logging is evident by the lack of more alarm messages.
Otherwise, your system logs alarms constantly every minute and this should be evident in dashboards
or elsewhere.