### PR TITLE
Add more alarms

### DIFF
--- a/src/alarms/__tests__/__snapshots__/database-alarms.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/database-alarms.test.ts.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`create alarms 1`] = `
+Object {
+  "Resources": Object {
+    "DatabaseAlarmsCpuUtilizationAlarmA27F08F4": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "RDS database 'database-name' has a higher than expected CPU utilization.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "DBInstanceIdentifier",
+            "Value": "database-name",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/RDS",
+        "OKActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "Period": 120,
+        "Statistic": "Average",
+        "Threshold": 75,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DatabaseAlarmsCreditsAlarm9AA09CB7": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "Less than 28.8 CPU credits remaining for RDS database 'database-name'. If the balance is depleted, AWS adds additional charges..",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "DBInstanceIdentifier",
+            "Value": "database-name",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUCreditBalance",
+        "Namespace": "AWS/RDS",
+        "Period": 300,
+        "Statistic": "Minimum",
+        "Threshold": 28.8,
+        "TreatMissingData": "ignore",
+        "Unit": "Count",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DatabaseAlarmsCriticallyLowStorageSpaceAlarm3F2C7F66": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "Critically low storage space available on RDS database 'database-name'.",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "DBInstanceIdentifier",
+            "Value": "database-name",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FreeStorageSpace",
+        "Namespace": "AWS/RDS",
+        "OKActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Minimum",
+        "Threshold": 1.25,
+        "TreatMissingData": "ignore",
+        "Unit": "Gigabytes",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DatabaseAlarmsLowStorageSpaceAlarm99A98D32": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "Low storage space available on RDS database 'database-name'.",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "DBInstanceIdentifier",
+            "Value": "database-name",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FreeStorageSpace",
+        "Namespace": "AWS/RDS",
+        "OKActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Minimum",
+        "Threshold": 6.25,
+        "TreatMissingData": "ignore",
+        "Unit": "Gigabytes",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+  },
+}
+`;

--- a/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
@@ -27,7 +27,7 @@ Object {
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "ServiceAlarmsConnectionAlarm1F083C01": Object {
+    "ServiceAlarmsAlbTargets5xxAlarm55A1710E": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
@@ -35,7 +35,37 @@ Object {
             "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
           },
         ],
-        "AlarmDescription": "Load balancer could not connect to target",
+        "AlarmDescription": "Load balancer received too many 5XX responses from target(s) in ECS service 'service-name'.",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": "app/my-load-balancer/50dc6c495c0c9188",
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": "targetgroup/my-target-group/cbf133c568e0d028",
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "HTTPCode_Target_5XX_Count",
+        "Namespace": "AWS/ApplicationELB",
+        "OKActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ServiceAlarmsConnectionAlarm1F083C01": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Load balancer is failing to connect to target(s) in ECS service 'service-name'.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": Array [
           Object {
@@ -50,11 +80,6 @@ Object {
         "EvaluationPeriods": 1,
         "MetricName": "TargetConnectionErrorCount",
         "Namespace": "AWS/ApplicationELB",
-        "OKActions": Array [
-          Object {
-            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
-          },
-        ],
         "Period": 60,
         "Statistic": "Sum",
         "Threshold": 1,
@@ -88,12 +113,7 @@ Object {
     },
     "ServiceAlarmsHealthAlarm888BAAB5": Object {
       "Properties": Object {
-        "AlarmActions": Array [
-          Object {
-            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
-          },
-        ],
-        "AlarmDescription": "Service might be unavailable! It is not responding to health checks.",
+        "AlarmDescription": "There are no healthy target(s) in ECS service 'service-name'.",
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": Array [
           Object {
@@ -108,15 +128,85 @@ Object {
         "EvaluationPeriods": 1,
         "MetricName": "HealthyHostCount",
         "Namespace": "AWS/ApplicationELB",
+        "Period": 60,
+        "Statistic": "Minimum",
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ServiceAlarmsTargetHealthAlarm18599060": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "The load balancer is either receiving bad health checks from or is unable to connect to target(s) in ECS service 'service-name'",
+        "AlarmName": "StackServiceAlarmsTargetHealthAlarm30873D46",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ServiceAlarmsConnectionAlarm1F083C01",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ServiceAlarmsHealthAlarm888BAAB5",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
         "OKActions": Array [
           Object {
             "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
           },
         ],
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 1,
-        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "ServiceAlarmsTargetResponseTimeAlarmA0DC0898": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "5% of responses from ECS service 'service-name' are taking longer than expected.",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": "app/my-load-balancer/50dc6c495c0c9188",
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": "targetgroup/my-target-group/cbf133c568e0d028",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "ExtendedStatistic": "p(95)",
+        "MetricName": "TargetResponseTime",
+        "Namespace": "AWS/ApplicationELB",
+        "OKActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "Period": 300,
+        "Threshold": 500,
+        "TreatMissingData": "ignore",
+        "Unit": "Milliseconds",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/src/alarms/__tests__/database-alarms.test.ts
+++ b/src/alarms/__tests__/database-alarms.test.ts
@@ -1,0 +1,35 @@
+import "@aws-cdk/assert/jest"
+import { App, Stack, Size } from "aws-cdk-lib"
+import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions"
+import * as sns from "aws-cdk-lib/aws-sns"
+import * as ec2 from "aws-cdk-lib/aws-ec2"
+import "jest-cdk-snapshot"
+import { DatabaseAlarms } from "../database-alarms"
+
+test("create alarms", () => {
+  const app = new App()
+  const supportStack = new Stack(app, "SupportStack")
+  const stack = new Stack(app, "Stack")
+
+  const topic = new sns.Topic(supportStack, "Topic")
+  const action = new cloudwatchActions.SnsAction(topic)
+
+  const alarms = new DatabaseAlarms(stack, "DatabaseAlarms", {
+    instanceIdentifier: "database-name",
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    allocatedStorage: Size.gibibytes(25),
+    action,
+  })
+
+  alarms.addCpuCreditsAlarm()
+  alarms.addCpuUtilizationAlarm({
+    threshold: 75,
+  })
+
+  alarms.addStorageSpaceAlarms()
+
+  expect(stack).toMatchCdkSnapshot()
+})

--- a/src/alarms/__tests__/service-alarms.test.ts
+++ b/src/alarms/__tests__/service-alarms.test.ts
@@ -1,8 +1,8 @@
 import "@aws-cdk/assert/jest"
+import { App, Stack } from "aws-cdk-lib"
 import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions"
 import * as logs from "aws-cdk-lib/aws-logs"
 import * as sns from "aws-cdk-lib/aws-sns"
-import { App, Stack } from "aws-cdk-lib"
 import "jest-cdk-snapshot"
 import { ServiceAlarms } from "../service-alarms"
 
@@ -25,7 +25,7 @@ test("create alarms", () => {
     logGroup,
   })
 
-  alarms.addTargetGroupAlarm({
+  alarms.addTargetGroupAlarms({
     loadBalancerFullName: "app/my-load-balancer/50dc6c495c0c9188",
     targetGroupFullName: "targetgroup/my-target-group/cbf133c568e0d028",
   })

--- a/src/alarms/database-alarms.ts
+++ b/src/alarms/database-alarms.ts
@@ -1,0 +1,294 @@
+import * as constructs from "constructs"
+import * as cdk from "aws-cdk-lib"
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch"
+import * as ec2 from "aws-cdk-lib/aws-ec2"
+import { Unit } from "aws-cdk-lib/aws-cloudwatch"
+
+export interface DatabaseAlarmsProps {
+  /**
+   * The default action to use for CloudWatch alarm state changes
+   */
+  action: cloudwatch.IAlarmAction
+  instanceIdentifier: string
+  instanceType: ec2.InstanceType
+  allocatedStorage: cdk.Size
+}
+
+// Based on https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html#earning-CPU-credits
+const cpuCreditBalanceByInstanceType: {
+  [instanceType: string]: number
+} = {
+  "t2.nano": 72,
+  "t2.micro": 144,
+  "t2.small": 288,
+  "t2.medium": 576,
+  "t2.large": 864,
+  "t2.xlarge": 1296,
+  "t2.2xlarge": 1958.4,
+  "t3.nano": 144,
+  "t3.micro": 288,
+  "t3.small": 576,
+  "t3.medium": 576,
+  "t3.large": 864,
+  "t3.xlarge": 2304,
+  "t3.2xlarge": 4608,
+  "t3a.nano": 144,
+  "t3a.micro": 288,
+  "t3a.small": 576,
+  "t3a.medium": 576,
+  "t3a.large": 864,
+  "t3a.xlarge": 2304,
+  "t3a.2xlarge": 4608,
+  "t4g.nano": 144,
+  "t4g.micro": 288,
+  "t4g.small": 576,
+  "t4g.medium": 576,
+  "t4g.large": 864,
+  "t4g.xlarge": 2304,
+  "t4g.2xlarge": 4608,
+}
+
+export class DatabaseAlarms extends constructs.Construct {
+  private readonly action: cloudwatch.IAlarmAction
+  private readonly databaseInstanceIdentifier: string
+  private readonly instanceType: ec2.InstanceType
+  private readonly allocatedStorage: cdk.Size
+
+  constructor(
+    scope: constructs.Construct,
+    id: string,
+    props: DatabaseAlarmsProps,
+  ) {
+    super(scope, id)
+
+    this.action = props.action
+    this.databaseInstanceIdentifier = props.instanceIdentifier
+    this.instanceType = props.instanceType
+    this.allocatedStorage = props.allocatedStorage
+  }
+
+  /**
+   * Sets up a CloudWatch Alarm that triggers if the CPU credit balance for
+   * a burstable instance breach a certain threshold.
+   *
+   * NOTE: This alarm is only applicable for burstable instances, and a balance of 0 credits will only have performance
+   * implications for T2 instances. T3 and T4g instances will instead cost more for prolonged high CPU utilization after
+   * the balance is depleted.
+   */
+  addCpuCreditsAlarm(
+    /**
+     * Configuration for an alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    props?: {
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * The CloudWatch Alarm will change its state to ALARM if the number of CPU credits drops below this threshold.
+       *
+       * See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-credits-baseline-concepts.html#earning-CPU-credits for an overview of maximum CPU credits for various instance types.
+       *
+       * @default 10% of the maximum earned CPU credits for the instance type.
+       */
+      threshold?: number
+    },
+  ): void {
+    if (
+      !["t2.", "t3.", "t4g."].some((s) =>
+        this.instanceType.toString().startsWith(s),
+      )
+    ) {
+      throw new Error(
+        "CPU credits are only relevant for burstable instance types.",
+      )
+    }
+
+    const defaultThreshold =
+      cpuCreditBalanceByInstanceType[this.instanceType.toString()] * 0.1
+    const threshold = props?.threshold ?? defaultThreshold
+    if (!threshold) {
+      throw new Error(
+        `No threshold supplied, and unable to determine a default value for instance type '${this.instanceType.toString()}'`,
+      )
+    }
+    new cloudwatch.Metric({
+      metricName: "CPUCreditBalance",
+      namespace: "AWS/RDS",
+      statistic: "Minimum",
+      unit: Unit.COUNT,
+      period: cdk.Duration.minutes(5),
+      dimensionsMap: {
+        DBInstanceIdentifier: this.databaseInstanceIdentifier,
+      },
+    })
+      .createAlarm(this, "CreditsAlarm", {
+        alarmDescription: `Less than ${threshold} CPU credits remaining for RDS database '${
+          this.databaseInstanceIdentifier
+        }'. ${
+          this.instanceType.toString().startsWith("t2.")
+            ? "If this reaches 0, the instance will be limited to a baseline CPU utilization."
+            : "If the balance is depleted, AWS adds additional charges."
+        }.`,
+        comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        evaluationPeriods: 1,
+        threshold: threshold,
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+      })
+      .addAlarmAction(this.action)
+  }
+
+  /**
+   * Sets up two CloudWatch Alarms for monitoring disk storage space:
+   * 1) one that triggers if the available disk storage space is low.
+   * 2) one that triggers if the available disk storage space is critcally low.
+   *
+   * You may want to use different alarm actions for the two alarms, e.g., one can be
+   * categorized as a "warning", while the other one can be considered an "alarm".
+   */
+  addStorageSpaceAlarms(props?: {
+    /**
+     * Configuration for an alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    lowStorageSpaceAlarm?: {
+      /**
+       * @default true
+       */
+      enabled?: boolean
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * @default 25% of the allocated storage.
+       */
+      threshold?: cdk.Size
+    }
+    /**
+     * Configuration for an alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    criticallyLowStorageSpaceAlarm?: {
+      /**
+       * @default true
+       */
+      enabled?: boolean
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * @default 5% of the allocated storage.
+       */
+      threshold?: cdk.Size
+    }
+  }): void {
+    const lowStorageSpaceAlarm = new cloudwatch.Metric({
+      metricName: "FreeStorageSpace",
+      namespace: "AWS/RDS",
+      statistic: "Minimum",
+      unit: Unit.GIGABYTES,
+      period: cdk.Duration.minutes(5),
+      dimensionsMap: {
+        DBInstanceIdentifier: this.databaseInstanceIdentifier,
+      },
+    }).createAlarm(this, "LowStorageSpaceAlarm", {
+      alarmDescription: `Low storage space available on RDS database '${this.databaseInstanceIdentifier}'.`,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 1,
+      threshold:
+        props?.lowStorageSpaceAlarm?.threshold?.toGibibytes() ??
+        this.allocatedStorage.toGibibytes() * 0.25,
+      treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+    })
+    if (props?.lowStorageSpaceAlarm?.enabled ?? true) {
+      lowStorageSpaceAlarm.addAlarmAction(
+        props?.lowStorageSpaceAlarm?.action || this.action,
+      )
+      lowStorageSpaceAlarm.addOkAction(
+        props?.lowStorageSpaceAlarm?.action || this.action,
+      )
+    }
+
+    const criticallyLowStorageSpaceAlarm = new cloudwatch.Metric({
+      metricName: "FreeStorageSpace",
+      namespace: "AWS/RDS",
+      statistic: "Minimum",
+      unit: Unit.GIGABYTES,
+      period: cdk.Duration.minutes(5),
+      dimensionsMap: {
+        DBInstanceIdentifier: this.databaseInstanceIdentifier,
+      },
+    }).createAlarm(this, "CriticallyLowStorageSpaceAlarm", {
+      alarmDescription: `Critically low storage space available on RDS database '${this.databaseInstanceIdentifier}'.`,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 1,
+      threshold:
+        props?.criticallyLowStorageSpaceAlarm?.threshold?.toGibibytes() ??
+        this.allocatedStorage.toGibibytes() * 0.05,
+      treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+    })
+    if (props?.criticallyLowStorageSpaceAlarm?.enabled ?? true) {
+      criticallyLowStorageSpaceAlarm.addAlarmAction(
+        props?.criticallyLowStorageSpaceAlarm?.action || this.action,
+      )
+      criticallyLowStorageSpaceAlarm.addOkAction(
+        props?.criticallyLowStorageSpaceAlarm?.action || this.action,
+      )
+    }
+  }
+
+  /**
+   * Sets up a CloudWatch Alarm that triggers if the average CPU utilization for
+   * the RDS instance exceeds a given threshold.
+   */
+  addCpuUtilizationAlarm(
+    /**
+     * Configuration for an alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    props?: {
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * The threshold defined as a percentage that determines if CPU utilization should trigger an alarm or not.
+       * @default 80
+       */
+      threshold?: number
+      /**
+       * @default 5
+       */
+      evaluationPeriods?: number
+      /**
+       * @default 2 minutes
+       */
+      period?: cdk.Duration
+    },
+  ): void {
+    const alarm = new cloudwatch.Metric({
+      metricName: "CPUUtilization",
+      namespace: "AWS/RDS",
+      statistic: "Average",
+      period: props?.period ?? cdk.Duration.minutes(2),
+      dimensionsMap: {
+        DBInstanceIdentifier: this.databaseInstanceIdentifier,
+      },
+    }).createAlarm(this, "CpuUtilizationAlarm", {
+      alarmDescription: `RDS database '${this.databaseInstanceIdentifier}' has a higher than expected CPU utilization.`,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: props?.evaluationPeriods ?? 5,
+      threshold: props?.threshold ?? 80,
+      treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+    })
+    alarm.addAlarmAction(props?.action ?? this.action)
+    alarm.addOkAction(props?.action ?? this.action)
+  }
+}

--- a/src/alarms/index.ts
+++ b/src/alarms/index.ts
@@ -1,2 +1,3 @@
+export { DatabaseAlarms, DatabaseAlarmsProps } from "./database-alarms"
 export { ServiceAlarms, ServiceAlarmsProps } from "./service-alarms"
 export { SlackAlarm, SlackAlarmProps } from "./slack-alarm"

--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -1,10 +1,16 @@
-import * as constructs from "constructs"
+import * as cdk from "aws-cdk-lib"
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch"
 import * as logs from "aws-cdk-lib/aws-logs"
-import * as cdk from "aws-cdk-lib"
+import * as constructs from "constructs"
 
 export interface ServiceAlarmsProps extends cdk.StackProps {
+  /**
+   * The default action to use for CloudWatch alarm state changes
+   */
   action: cloudwatch.IAlarmAction
+  /**
+   * The name of the ECS service.
+   */
   serviceName: string
 }
 
@@ -39,9 +45,15 @@ export class ServiceAlarms extends constructs.Construct {
   addJsonErrorAlarm(props: {
     logGroup: logs.ILogGroup
     alarmDescription?: string
-    /** Set to `false` to stop the alarm from sending OK events.
-     * @default true */
+    /**
+     * Set to `false` to stop the alarm from sending OK events.
+     * @default true
+     * */
     enableOkAction?: boolean
+    /**
+     * An action to use for CloudWatch alarm state changes instead of the default action
+     */
+    action?: cloudwatch.IAlarmAction
   }): void {
     const errorMetricFilter = props.logGroup.addMetricFilter(
       "ErrorMetricFilter",
@@ -79,58 +91,233 @@ export class ServiceAlarms extends constructs.Construct {
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       })
 
-    errorAlarm.addAlarmAction(this.action)
+    errorAlarm.addAlarmAction(props.action ?? this.action)
     if (props.enableOkAction ?? true) {
-      errorAlarm.addOkAction(this.action)
+      errorAlarm.addOkAction(props.action ?? this.action)
     }
   }
 
   /**
-   * Monitor healthy host count and connection errors from load balancer.
+   * Sets up three CloudWatch Alarms for monitoring an ECS service behind a target group:
+   * 1) one that triggers if the target is responding with too many 5xx errors.
+   * 2) one that triggers if the 95% percentile of response times from the target is too high.
+   * 3) one that triggers if there are no healthy targets or if the load balancer fails to connect to targets.
    */
-  addTargetGroupAlarm(props: {
+  addTargetGroupAlarms(props: {
+    /**
+     * The full name of the target group.
+     */
     targetGroupFullName: string
+    /**
+     * The full name of the application load balancer.
+     */
     loadBalancerFullName: string
+    /**
+     * Configuration for a composite alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    targetHealthAlarm?: {
+      /**
+       * @default true
+       */
+      enabled?: boolean
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * @default 60 seconds
+       */
+      period?: cdk.Duration
+      /**
+       * @default 1
+       */
+      evaluationPeriods?: number
+      /**
+       * @default 1
+       */
+      threshold?: number
+      description?: string
+    }
+    /**
+     * Configuration for an alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    tooMany5xxResponsesFromTargetsAlarm?: {
+      /**
+       * @default true
+       */
+      enabled?: boolean
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * @default 60 seconds
+       */
+      period?: cdk.Duration
+      /**
+       * @default 3
+       */
+      evaluationPeriods?: number
+      /**
+       * @default 10
+       */
+      threshold?: number
+      description?: string
+    }
+    /**
+     * Configuration for an alarm.
+     *
+     * @default Configured with sane defaults.
+     */
+    targetResponseTimeAlarm?: {
+      /**
+       * @default true
+       */
+      enabled?: boolean
+      /**
+       * An action to use for CloudWatch alarm state changes instead of the default action
+       */
+      action?: cloudwatch.IAlarmAction
+      /**
+       * @default 5 minutes
+       */
+      period?: cdk.Duration
+      /**
+       * @default 1
+       */
+      evaluationPeriods?: number
+      /**
+       * @default 500 milliseconds
+       */
+      threshold?: cdk.Duration
+      description?: string
+    }
   }): void {
-    const healthAlarm = new cloudwatch.Metric({
-      metricName: "HealthyHostCount",
-      namespace: "AWS/ApplicationELB",
-      statistic: "Average",
-      period: cdk.Duration.seconds(60),
-      dimensionsMap: {
-        TargetGroup: props.targetGroupFullName,
-        LoadBalancer: props.loadBalancerFullName,
-      },
-    }).createAlarm(this, "HealthAlarm", {
-      alarmDescription:
-        "Service might be unavailable! It is not responding to health checks.",
-      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-      evaluationPeriods: 1,
-      threshold: 1,
-      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
-    })
-
-    healthAlarm.addAlarmAction(this.action)
-    healthAlarm.addOkAction(this.action)
-
-    const connectionAlarm = new cloudwatch.Metric({
+    const targetConnectionErrorAlarm = new cloudwatch.Metric({
       metricName: "TargetConnectionErrorCount",
       namespace: "AWS/ApplicationELB",
       statistic: "Sum",
-      period: cdk.Duration.seconds(60),
+      period: props.targetHealthAlarm?.period ?? cdk.Duration.seconds(60),
       dimensionsMap: {
         TargetGroup: props.targetGroupFullName,
         LoadBalancer: props.loadBalancerFullName,
       },
     }).createAlarm(this, "ConnectionAlarm", {
       actionsEnabled: true,
-      alarmDescription: "Load balancer could not connect to target",
-      evaluationPeriods: 1,
+      alarmDescription: `Load balancer is failing to connect to target(s) in ECS service '${this.serviceName}'.`,
+      evaluationPeriods: props.targetHealthAlarm?.evaluationPeriods ?? 1,
       threshold: 1,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     })
 
-    connectionAlarm.addAlarmAction(this.action)
-    connectionAlarm.addOkAction(this.action)
+    const healthAlarm = new cloudwatch.Metric({
+      metricName: "HealthyHostCount",
+      namespace: "AWS/ApplicationELB",
+      statistic: "Minimum",
+      period: props.targetHealthAlarm?.period ?? cdk.Duration.seconds(60),
+      dimensionsMap: {
+        TargetGroup: props.targetGroupFullName,
+        LoadBalancer: props.loadBalancerFullName,
+      },
+    }).createAlarm(this, "HealthAlarm", {
+      alarmDescription: `There are no healthy target(s) in ECS service '${this.serviceName}'.`,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: props.targetHealthAlarm?.evaluationPeriods ?? 1,
+      threshold: 1,
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+    })
+
+    const targetHealthAlarm = new cloudwatch.CompositeAlarm(
+      this,
+      "TargetHealthAlarm",
+      {
+        alarmRule: cdk.aws_cloudwatch.AlarmRule.anyOf(
+          cdk.aws_cloudwatch.AlarmRule.fromAlarm(
+            targetConnectionErrorAlarm,
+            cloudwatch.AlarmState.ALARM,
+          ),
+          cdk.aws_cloudwatch.AlarmRule.fromAlarm(
+            healthAlarm,
+            cloudwatch.AlarmState.ALARM,
+          ),
+        ),
+        alarmDescription:
+          props.targetHealthAlarm?.description ??
+          `The load balancer is either receiving bad health checks from or is unable to connect to target(s) in ECS service '${this.serviceName}'`,
+        actionsEnabled: false,
+      },
+    )
+    if (props.targetHealthAlarm?.enabled ?? true) {
+      targetHealthAlarm.addAlarmAction(
+        props.targetHealthAlarm?.action ?? this.action,
+      )
+      targetHealthAlarm.addOkAction(
+        props.targetHealthAlarm?.action ?? this.action,
+      )
+    }
+
+    const tooMany5xxResponsesFromTargetsAlarm = new cloudwatch.Metric({
+      metricName: "HTTPCode_Target_5XX_Count",
+      namespace: "AWS/ApplicationELB",
+      statistic: "Sum",
+      period:
+        props.tooMany5xxResponsesFromTargetsAlarm?.period ??
+        cdk.Duration.seconds(60),
+      dimensionsMap: {
+        TargetGroup: props.targetGroupFullName,
+        LoadBalancer: props.loadBalancerFullName,
+      },
+    }).createAlarm(this, "AlbTargets5xxAlarm", {
+      actionsEnabled: true,
+      alarmDescription:
+        props.tooMany5xxResponsesFromTargetsAlarm?.description ??
+        `Load balancer received too many 5XX responses from target(s) in ECS service '${this.serviceName}'.`,
+      evaluationPeriods:
+        props.tooMany5xxResponsesFromTargetsAlarm?.evaluationPeriods ?? 3,
+      threshold: props.tooMany5xxResponsesFromTargetsAlarm?.threshold ?? 10,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    })
+    if (props.tooMany5xxResponsesFromTargetsAlarm?.enabled ?? true) {
+      tooMany5xxResponsesFromTargetsAlarm.addAlarmAction(
+        props.tooMany5xxResponsesFromTargetsAlarm?.action ?? this.action,
+      )
+      tooMany5xxResponsesFromTargetsAlarm.addOkAction(
+        props.tooMany5xxResponsesFromTargetsAlarm?.action ?? this.action,
+      )
+    }
+
+    const targetResponseTimeAlarm = new cloudwatch.Metric({
+      metricName: "TargetResponseTime",
+      namespace: "AWS/ApplicationELB",
+      statistic: "p(95)",
+      period: props.targetResponseTimeAlarm?.period ?? cdk.Duration.minutes(5),
+      unit: cloudwatch.Unit.MILLISECONDS,
+      dimensionsMap: {
+        LoadBalancer: props.loadBalancerFullName,
+        TargetGroup: props.targetGroupFullName,
+      },
+    }).createAlarm(this, "TargetResponseTimeAlarm", {
+      alarmDescription:
+        props.targetResponseTimeAlarm?.description ??
+        `5% of responses from ECS service '${this.serviceName}' are taking longer than expected.`,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: props.targetResponseTimeAlarm?.evaluationPeriods ?? 1,
+      threshold: (
+        props.targetResponseTimeAlarm?.threshold ?? cdk.Duration.millis(500)
+      ).toMilliseconds(),
+      treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+    })
+    if (props.targetResponseTimeAlarm?.enabled ?? true) {
+      targetResponseTimeAlarm.addAlarmAction(
+        props.targetResponseTimeAlarm?.action ?? this.action,
+      )
+      targetResponseTimeAlarm.addOkAction(
+        props.targetResponseTimeAlarm?.action ?? this.action,
+      )
+    }
   }
 }

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -43,6 +43,9 @@ export interface DatabaseProps extends cdk.StackProps {
 export class Database extends constructs.Construct {
   public readonly secret: sm.ISecret
   public readonly connections: ec2.Connections
+  public readonly databaseInstance: rds.IDatabaseInstance
+  public readonly instanceType: ec2.InstanceType
+  public readonly allocatedStorage: cdk.Size
 
   constructor(scope: constructs.Construct, id: string, props: DatabaseProps) {
     super(scope, id)
@@ -73,6 +76,8 @@ export class Database extends constructs.Construct {
       backupRetention: cdk.Duration.days(35),
       ...props.overrideDbOptions,
     }
+    this.allocatedStorage = cdk.Size.gibibytes(options.allocatedStorage!)
+    this.instanceType = options.instanceType!
 
     const db = props.snapshotIdentifier
       ? new rds.DatabaseInstanceFromSnapshot(this, "Resource", {
@@ -86,6 +91,8 @@ export class Database extends constructs.Construct {
           credentials: rds.Credentials.fromSecret(secret),
           storageEncrypted: true,
         })
+
+    this.databaseInstance = db
 
     this.secret = db.secret!
     this.connections = db.connections


### PR DESCRIPTION
- Add a construct for configuring alarms for RDS databases
- Add additional outputs from the RDS construct that are required for using the RDS alarm construct
- Add additional ALB-related alarms
- Add a composite alarm for monitoring health in and connectivity to a target group
- Allow the consumer to override the `action` to use for every alarm. This allows the consumer to define custom behavior for specific alarms.

## Breaking changes
- There are no separate alarm that will trigger for the alarms monitoring `HealthyHostCount` and `TargetConnectionErrorCount`. Instead these alarms have been included in a composite alarm as they tend to occur simultaneously.