### PR TITLE
fix: change "p(95)" to "p95" in service-alarms.ts

### DIFF
--- a/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
@@ -195,7 +195,7 @@ Object {
           },
         ],
         "EvaluationPeriods": 1,
-        "ExtendedStatistic": "p(95)",
+        "ExtendedStatistic": "p95",
         "MetricName": "TargetResponseTime",
         "Namespace": "AWS/ApplicationELB",
         "OKActions": Array [

--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -293,7 +293,7 @@ export class ServiceAlarms extends constructs.Construct {
     const targetResponseTimeAlarm = new cloudwatch.Metric({
       metricName: "TargetResponseTime",
       namespace: "AWS/ApplicationELB",
-      statistic: "p(95)",
+      statistic: "p95",
       period: props.targetResponseTimeAlarm?.period ?? cdk.Duration.minutes(5),
       unit: cloudwatch.Unit.MILLISECONDS,
       dimensionsMap: {


### PR DESCRIPTION
Fikser bug som ble introdusert her i service-alarms: 

https://github.com/capralifecycle/liflig-cdk/blob/7debf31d659decdea6ff7ea251753612cebad145/src/alarms/service-alarms.ts#L296 

Fikk feilmelding da jeg prøvde å rulle ut en stack som tar denne i bruk etter å ha bumpet liflig-cdk til v2.8.0- 

_The value p(95) for parameter ExtendedStatistic is not supported. (Service: AmazonCloudWatch; Status Code: 400; Error Code: InvalidParameterValue; Request ID_ 

Testet å endre "p(95)" til "p95" i CloudFormation fordi det så ut til å være riktig format ifølge denne siden - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html. Da fikk jeg rullet ut stacken, og alarmen ble opprettet med forventet config.

PRen gjør samme endring i liflig-cdk.