### PR TITLE
Fix ssm deprecation warning

### DIFF
--- a/src/__tests__/ssm-parameter-reader.test.ts
+++ b/src/__tests__/ssm-parameter-reader.test.ts
@@ -1,4 +1,4 @@
-import { CfnParameter, ParameterType } from "aws-cdk-lib/aws-ssm"
+import { CfnParameter } from "aws-cdk-lib/aws-ssm"
 import { App, Stack } from "aws-cdk-lib"
 import "jest-cdk-snapshot"
 import { SsmParameterReader } from "../ssm-parameter-reader"
@@ -9,7 +9,7 @@ test("ssm-parameter-reader", () => {
   const parameterName = "/my/param"
 
   new CfnParameter(stack1, "Param", {
-    type: ParameterType.STRING,
+    type: "String",
     name: parameterName,
     value: "test",
   })

--- a/src/configure-parameters/configure-parameters.ts
+++ b/src/configure-parameters/configure-parameters.ts
@@ -92,7 +92,6 @@ export class ConfigureParameters {
 
     this.configParameters.forEach((it) => {
       const param = new ssm.StringParameter(scope, `Config${it.key}`, {
-        type: ssm.ParameterType.STRING,
         stringValue: it.value,
         parameterName: `${this.ssmPrefix}/config/${it.key}`,
       })
@@ -101,7 +100,6 @@ export class ConfigureParameters {
 
     this.secretParameters.forEach((it) => {
       const param = new ssm.StringParameter(scope, `Secret${it.key}`, {
-        type: ssm.ParameterType.STRING,
         stringValue: it.secret.secretArn,
         parameterName: `${this.ssmPrefix}/secrets/${it.key}`,
       })

--- a/src/hosted-zone-with-param.ts
+++ b/src/hosted-zone-with-param.ts
@@ -38,7 +38,7 @@ export class HostedZoneWithParam extends constructs.Construct {
     this.hostedZone = new route53.HostedZone(this, "Resource", props)
 
     new ssm.CfnParameter(this, "IdParam", {
-      type: ssm.ParameterType.STRING,
+      type: "String",
       name: this.idParamName,
       value: this.hostedZone.hostedZoneId,
     })


### PR DESCRIPTION
The `ssm.ParameterType` attribute has been deprecated along with the `type` parameter of `ssm.StringParameter`.

This PR removes usage of these deprecated API elements to remove warnings that are output by newer versions of CDK.

## Breaking changes
None.