### PR TITLE
feat: use latest amazon-managed codebuild image

### DIFF
--- a/__snapshots__/app/cdk-pipeline-cdk-source.template.json
+++ b/__snapshots__/app/cdk-pipeline-cdk-source.template.json
@@ -1492,7 +1492,7 @@
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:5.0",
+          "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER"

--- a/src/cdk-pipelines/liflig-cdk-pipeline.ts
+++ b/src/cdk-pipelines/liflig-cdk-pipeline.ts
@@ -1,5 +1,6 @@
 import * as constructs from "constructs"
 import * as codepipeline from "aws-cdk-lib/aws-codepipeline"
+import * as codebuild from "aws-cdk-lib/aws-codebuild"
 import * as codepipelineActions from "aws-cdk-lib/aws-codepipeline-actions"
 import * as iam from "aws-cdk-lib/aws-iam"
 import * as lambda from "aws-cdk-lib/aws-lambda"
@@ -183,6 +184,11 @@ export class LifligCdkPipeline extends constructs.Construct {
     this.cdkPipeline = new pipelines.CodePipeline(this, "CdkPipeline", {
       synth,
       codePipeline: this.codePipeline,
+      synthCodeBuildDefaults: {
+        buildEnvironment: {
+          buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
+        },
+      },
     })
   }
 


### PR DESCRIPTION
This, among other things, has Node v16 and NPM >= v7 in the CodeBuild job that synthesizes the CDK application. This should mitigate some of the issues that can occur when using older Node and NPM versions.