### PR TITLE
feat: default security headers for webapp

### DIFF
--- a/__snapshots__/app/manifest.json
+++ b/__snapshots__/app/manifest.json
@@ -1515,6 +1515,12 @@
             "data": "WebappOriginAccessIdentityA216A4CF"
           }
         ],
+        "/webapp/Webapp/SecurityHeaders/ResponseHeadersPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "WebappSecurityHeadersResponseHeadersPolicyF5614597"
+          }
+        ],
         "/webapp/Webapp/Distribution/Resource": [
           {
             "type": "aws:cdk:logicalId",

--- a/__snapshots__/app/webapp.template.json
+++ b/__snapshots__/app/webapp.template.json
@@ -104,6 +104,45 @@
         "aws:cdk:path": "webapp/Webapp/OriginAccessIdentity/Resource"
       }
     },
+    "WebappSecurityHeadersResponseHeadersPolicyF5614597": {
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
+      "Properties": {
+        "ResponseHeadersPolicyConfig": {
+          "Name": "webappWebappSecurityHeadersResponseHeadersPolicyB14BCA0D",
+          "SecurityHeadersConfig": {
+            "ContentSecurityPolicy": {
+              "ContentSecurityPolicy": "base-uri 'self';child-src 'self';connect-src 'self' https:;default-src 'none';font-src 'self';frame-src 'self';img-src 'self' data:;manifest-src 'self';media-src 'self';object-src 'none';script-src 'self';style-src 'self'",
+              "Override": true
+            },
+            "ContentTypeOptions": {
+              "Override": true
+            },
+            "FrameOptions": {
+              "FrameOption": "DENY",
+              "Override": true
+            },
+            "ReferrerPolicy": {
+              "Override": true,
+              "ReferrerPolicy": "same-origin"
+            },
+            "StrictTransportSecurity": {
+              "AccessControlMaxAgeSec": 15768000,
+              "IncludeSubdomains": false,
+              "Override": true,
+              "Preload": false
+            },
+            "XSSProtection": {
+              "ModeBlock": true,
+              "Override": true,
+              "Protection": true
+            }
+          }
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "webapp/Webapp/SecurityHeaders/ResponseHeadersPolicy/Resource"
+      }
+    },
     "WebappDistribution43D777AD": {
       "Type": "AWS::CloudFront::Distribution",
       "Properties": {
@@ -121,6 +160,9 @@
           "DefaultCacheBehavior": {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
             "Compress": true,
+            "ResponseHeadersPolicyId": {
+              "Ref": "WebappSecurityHeadersResponseHeadersPolicyF5614597"
+            },
             "TargetOriginId": "webappWebappDistributionOrigin103015323",
             "ViewerProtocolPolicy": "redirect-to-https"
           },

--- a/src/webapp/__tests__/__snapshots__/webapp.test.ts.snap
+++ b/src/webapp/__tests__/__snapshots__/webapp.test.ts.snap
@@ -89,6 +89,9 @@ Object {
           "DefaultCacheBehavior": Object {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
             "Compress": true,
+            "ResponseHeadersPolicyId": Object {
+              "Ref": "WebappSecurityHeadersResponseHeadersPolicyF5614597",
+            },
             "TargetOriginId": "StackWebappDistributionOrigin1098E590D",
             "ViewerProtocolPolicy": "redirect-to-https",
           },
@@ -133,6 +136,405 @@ Object {
         },
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "WebappSecurityHeadersResponseHeadersPolicyF5614597": Object {
+      "Properties": Object {
+        "ResponseHeadersPolicyConfig": Object {
+          "Name": "StackWebappSecurityHeadersResponseHeadersPolicyD3A7BCA3",
+          "SecurityHeadersConfig": Object {
+            "ContentSecurityPolicy": Object {
+              "ContentSecurityPolicy": "base-uri 'self';child-src 'self';connect-src 'self' https:;default-src 'none';font-src 'self';frame-src 'self';img-src 'self' data:;manifest-src 'self';media-src 'self';object-src 'none';script-src 'self';style-src 'self'",
+              "Override": true,
+            },
+            "ContentTypeOptions": Object {
+              "Override": true,
+            },
+            "FrameOptions": Object {
+              "FrameOption": "DENY",
+              "Override": true,
+            },
+            "ReferrerPolicy": Object {
+              "Override": true,
+              "ReferrerPolicy": "same-origin",
+            },
+            "StrictTransportSecurity": Object {
+              "AccessControlMaxAgeSec": 15768000,
+              "IncludeSubdomains": false,
+              "Override": true,
+              "Preload": false,
+            },
+            "XSSProtection": Object {
+              "ModeBlock": true,
+              "Override": true,
+              "Protection": true,
+            },
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
+    },
+  },
+}
+`;
+
+exports[`create webapp with domain and custom response header policy with CSP 1`] = `
+Object {
+  "Resources": Object {
+    "WebappBucketD38541E4": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "WebappBucketPolicy4224ABFE": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "WebappBucketD38541E4",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "WebappOriginAccessIdentityA216A4CF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "WebappBucketD38541E4",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "WebappOriginAccessIdentityA216A4CF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "WebappBucketD38541E4",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "WebappDistribution43D777AD": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "Aliases": Array [
+            "example.com",
+          ],
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "ResponseHeadersPolicyId": Object {
+              "Ref": "WebappSecurityHeadersResponseHeadersPolicyF5614597",
+            },
+            "TargetOriginId": "StackWebappDistributionOrigin1098E590D",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "WebappBucketD38541E4",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "StackWebappDistributionOrigin1098E590D",
+              "OriginPath": "/web",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "WebappOriginAccessIdentityA216A4CF",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_100",
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "WebappOriginAccessIdentityA216A4CF": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Allows CloudFront to reach the bucket",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "WebappSecurityHeadersResponseHeadersPolicyF5614597": Object {
+      "Properties": Object {
+        "ResponseHeadersPolicyConfig": Object {
+          "Name": "StackWebappSecurityHeadersResponseHeadersPolicyD3A7BCA3",
+          "SecurityHeadersConfig": Object {
+            "ContentSecurityPolicy": Object {
+              "ContentSecurityPolicy": "base-uri 'self';child-src 'self';connect-src 'self';default-src 'none';font-src 'self';frame-src 'self';img-src 'self' data:;manifest-src 'self';media-src 'self';object-src 'none';script-src 'self';style-src 'self'",
+              "Override": true,
+            },
+            "ContentTypeOptions": Object {
+              "Override": true,
+            },
+            "FrameOptions": Object {
+              "FrameOption": "DENY",
+              "Override": true,
+            },
+            "ReferrerPolicy": Object {
+              "Override": true,
+              "ReferrerPolicy": "same-origin",
+            },
+            "StrictTransportSecurity": Object {
+              "AccessControlMaxAgeSec": 15552000,
+              "Override": true,
+            },
+            "XSSProtection": Object {
+              "ModeBlock": true,
+              "Override": true,
+              "Protection": true,
+            },
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
+    },
+  },
+}
+`;
+
+exports[`create webapp with domain and custom response header policy with report-only CSP 1`] = `
+Object {
+  "Resources": Object {
+    "WebappBucketD38541E4": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "WebappBucketPolicy4224ABFE": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "WebappBucketD38541E4",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "WebappOriginAccessIdentityA216A4CF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "WebappBucketD38541E4",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "WebappOriginAccessIdentityA216A4CF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "WebappBucketD38541E4",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "WebappDistribution43D777AD": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "Aliases": Array [
+            "example.com",
+          ],
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "ResponseHeadersPolicyId": Object {
+              "Ref": "WebappSecurityHeadersResponseHeadersPolicyF5614597",
+            },
+            "TargetOriginId": "StackWebappDistributionOrigin1098E590D",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "WebappBucketD38541E4",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "StackWebappDistributionOrigin1098E590D",
+              "OriginPath": "/web",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "WebappOriginAccessIdentityA216A4CF",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_100",
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "WebappOriginAccessIdentityA216A4CF": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Allows CloudFront to reach the bucket",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "WebappSecurityHeadersResponseHeadersPolicyF5614597": Object {
+      "Properties": Object {
+        "ResponseHeadersPolicyConfig": Object {
+          "CustomHeadersConfig": Object {
+            "Items": Array [
+              Object {
+                "Header": "Content-Security-Policy-Report-Only",
+                "Override": true,
+                "Value": "base-uri 'self';child-src 'self';connect-src 'self';default-src 'none';font-src 'self';frame-src 'self';img-src 'self' data:;manifest-src 'self';media-src 'self';object-src 'none';script-src 'self';style-src 'self'",
+              },
+            ],
+          },
+          "Name": "StackWebappSecurityHeadersResponseHeadersPolicyD3A7BCA3",
+          "SecurityHeadersConfig": Object {
+            "ContentTypeOptions": Object {
+              "Override": true,
+            },
+            "FrameOptions": Object {
+              "FrameOption": "DENY",
+              "Override": true,
+            },
+            "ReferrerPolicy": Object {
+              "Override": true,
+              "ReferrerPolicy": "same-origin",
+            },
+            "StrictTransportSecurity": Object {
+              "AccessControlMaxAgeSec": 15768000,
+              "IncludeSubdomains": false,
+              "Override": true,
+              "Preload": false,
+            },
+            "XSSProtection": Object {
+              "ModeBlock": false,
+              "Override": true,
+              "Protection": false,
+            },
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
     },
   },
 }
@@ -230,17 +632,9 @@ Object {
           "DefaultCacheBehavior": Object {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
             "Compress": true,
-            "FunctionAssociations": Array [
-              Object {
-                "EventType": "viewer-response",
-                "FunctionARN": Object {
-                  "Fn::GetAtt": Array [
-                    "WebappSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b5576786884CD5C",
-                    "FunctionARN",
-                  ],
-                },
-              },
-            ],
+            "ResponseHeadersPolicyId": Object {
+              "Ref": "WebappSecurityHeadersResponseHeadersPolicyF5614597",
+            },
             "TargetOriginId": "StackWebappDistributionOrigin1098E590D",
             "ViewerProtocolPolicy": "redirect-to-https",
           },
@@ -286,27 +680,41 @@ Object {
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
     },
-    "WebappSecurityHeadersFunctionc85c32e0a9f633a8edb409ebc4166047306b5576786884CD5C": Object {
+    "WebappSecurityHeadersResponseHeadersPolicyF5614597": Object {
       "Properties": Object {
-        "AutoPublish": true,
-        "FunctionCode": "function handler(event) {
-      var response = event.response;
-      var headers = response.headers;
-      headers['referrer-policy'] = {value: 'strict-origin-when-cross-origin'};
-      headers['strict-transport-security'] = {value: 'max-age=63072000;'};
-      headers['x-content-type-options'] = {value: 'nosniff'};
-      headers['x-frame-options'] = {value: 'DENY'};
-      headers['x-xss-protection'] = {value: '1; mode=block'};
-      headers['content-security-policy'] = {value: \\"base-uri 'self';child-src 'none';connect-src 'self';default-src 'self';font-src 'self';frame-src 'self';img-src 'self';manifest-src 'self';media-src 'self';object-src 'none';script-src 'self';style-src 'self';\\"};
-      return response;
-    }",
-        "FunctionConfig": Object {
-          "Comment": "Functionc85c32e0a9f633a8edb409ebc4166047306b557678",
-          "Runtime": "cloudfront-js-1.0",
+        "ResponseHeadersPolicyConfig": Object {
+          "Name": "StackWebappSecurityHeadersResponseHeadersPolicyD3A7BCA3",
+          "SecurityHeadersConfig": Object {
+            "ContentSecurityPolicy": Object {
+              "ContentSecurityPolicy": "base-uri 'self';child-src 'self';connect-src 'self' https:;default-src 'none';font-src 'self';frame-src 'self';img-src 'self' data:;manifest-src 'self';media-src 'self';object-src 'none';script-src 'self';style-src 'self'",
+              "Override": true,
+            },
+            "ContentTypeOptions": Object {
+              "Override": true,
+            },
+            "FrameOptions": Object {
+              "FrameOption": "DENY",
+              "Override": true,
+            },
+            "ReferrerPolicy": Object {
+              "Override": true,
+              "ReferrerPolicy": "same-origin",
+            },
+            "StrictTransportSecurity": Object {
+              "AccessControlMaxAgeSec": 15768000,
+              "IncludeSubdomains": false,
+              "Override": true,
+              "Preload": false,
+            },
+            "XSSProtection": Object {
+              "ModeBlock": true,
+              "Override": true,
+              "Protection": true,
+            },
+          },
         },
-        "Name": "Functionc85c32e0a9f633a8edb409ebc4166047306b557678",
       },
-      "Type": "AWS::CloudFront::Function",
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
     },
   },
 }

--- a/src/webapp/index.ts
+++ b/src/webapp/index.ts
@@ -1,1 +1,2 @@
 export { Webapp, WebappProps } from "./webapp"
+export { generateContentSecurityPolicyHeader } from "./security-headers"


### PR DESCRIPTION
Dagens oppsett lar deg definere en hel policy via **overrideCloudFrontBehaviourOptions**. 
Her har jeg ikke endret hvordan logikk rundt **overrideCloudFrontBehaviourOptions** er satt opp, men jeg har gjort at man også kan overskrive deler av default policyen med **securityHeadersOverrides**. Jeg vet ikke om det er ønskelig at det er to måter å gjøre dette på? Tenker det kan være en fordel at man kan bruke **overrideCloudFrontBehaviourOptions** hvis man allerede har en eksisterende policy som skal videreføres, men så heller bruke **securityHeadersOverrides** med nye oppsett og policies som ikke er så forskjellige fra default. Men det blir mer å vedlikeholde.

Ikke sett noe særlig på hvilke defaults som skal settes ennå.