### PR TITLE
fix: add fallback value for slack alarm messages

### DIFF
--- a/assets/slack-alarm-lambda/index.py
+++ b/assets/slack-alarm-lambda/index.py
@@ -23,15 +23,16 @@ def send_slack_notification(message, region):
         color = "danger"
     else:
         color = "good"
-
+    alarm_description = message["AlarmDescription"] or "Alarm is missing description"
     attachments = [{
         'color': color,
         'title_link': "https://console.aws.amazon.com/cloudwatch/home?region=" + region + "#alarm:alarmFilter=ANY;name=" + message['AlarmName'],
+        'fallback': f"{message['AlarmName']}: {alarm_description}",
         'fields': [
             {'title': 'Alarm Name',
              'value': message['AlarmName'], 'short': False},
             {'title': 'Alarm Description',
-             'value': message['AlarmDescription'], 'short': False},
+             'value': alarm_description, 'short': False},
             {'title': 'Account',
              'value': message['AWSAccountId'], 'short': True},
             {'title': 'Region', 'value': region, 'short': True},

--- a/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
@@ -12,7 +12,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "15e8a964cb6662296dc491a81d03a6822f38070737a65bbc66fee43a89cabefc.zip",
+          "S3Key": "515f8dcedb1a6f58fcd2b3599e9d6a52a70f656bcb76d304e18c16af76655075.zip",
         },
         "Description": "Receives CloudWatch Alarms through SNS and sends a formatted version to Slack",
         "Environment": Object {


### PR DESCRIPTION
The fallback field is among other things used as the content of the corresponding Slack notification. When this field is omitted, all notifications say "no preview available".