### PR TITLE
fix: remove graphviz files from CDK snapshots

### DIFF
--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -247,6 +247,9 @@ export async function createCloudAssemblySnapshot(
   // snapshots for asset changes.
   await del(path.join(dst, "**/*.assets.json"))
 
+  // Remove graphviz files generated when using CDK Pipelines
+  await del(path.join(dst, "**/*.dot"))
+
   // Transform the manifest to be more snapshot friendly.
   for (const file of glob.sync("**/manifest.json", { cwd: base })) {
     await prepareManifestFileForSnapshot(path.join(base, file))


### PR DESCRIPTION
AWS recently added GraphViz `.dot` files to the cloud assembly when using CDK pipelines (https://github.com/aws/aws-cdk/pull/24030). This isn't really useful for snapshots as we'll detect changes in the CloudFormation templates, so this PR removes such files when using the snapshot mechanism in liflig-cdk.