### PR TITLE
fix: update default image used by CDK Pipelines

### DIFF
--- a/__snapshots__/app/cdk-pipeline-cdk-source.template.json
+++ b/__snapshots__/app/cdk-pipeline-cdk-source.template.json
@@ -1492,7 +1492,7 @@
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:5.0",
+          "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER"
@@ -1868,7 +1868,7 @@
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:5.0",
+          "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER"

--- a/__snapshots__/app/cdk-pipeline-cloud-assembly.template.json
+++ b/__snapshots__/app/cdk-pipeline-cloud-assembly.template.json
@@ -1468,7 +1468,7 @@
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:5.0",
+          "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER"

--- a/src/cdk-pipelines/liflig-cdk-pipeline.ts
+++ b/src/cdk-pipelines/liflig-cdk-pipeline.ts
@@ -3,6 +3,7 @@ import * as codepipeline from "aws-cdk-lib/aws-codepipeline"
 import * as codepipelineActions from "aws-cdk-lib/aws-codepipeline-actions"
 import * as iam from "aws-cdk-lib/aws-iam"
 import * as lambda from "aws-cdk-lib/aws-lambda"
+import * as codebuild from "aws-cdk-lib/aws-codebuild"
 import * as s3 from "aws-cdk-lib/aws-s3"
 import * as cdk from "aws-cdk-lib"
 import * as pipelines from "aws-cdk-lib/pipelines"
@@ -182,6 +183,11 @@ export class LifligCdkPipeline extends constructs.Construct {
 
     this.cdkPipeline = new pipelines.CodePipeline(this, "CdkPipeline", {
       synth,
+      codeBuildDefaults: {
+        buildEnvironment: {
+          buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
+        },
+      },
       codePipeline: this.codePipeline,
     })
   }


### PR DESCRIPTION
AWS is deprecating aws/codebuild/standard:5.0 on March 30 2023. The image will not be updated after this date, and the image will not be cached by CodeBuild, resulting in longer deploy times.