### PR TITLE
Include threshold-value in TargetResponseTime alarm description

### DIFF
--- a/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
@@ -182,7 +182,7 @@ Object {
             "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
           },
         ],
-        "AlarmDescription": "5% of responses from ECS service 'service-name' are taking longer than expected.",
+        "AlarmDescription": "5% of responses from ECS service 'service-name' are taking longer than the expected duration of 500 ms.",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
           Object {

--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -302,7 +302,11 @@ export class ServiceAlarms extends constructs.Construct {
     }).createAlarm(this, "TargetResponseTimeAlarm", {
       alarmDescription:
         props.targetResponseTimeAlarm?.description ??
-        `5% of responses from ECS service '${this.serviceName}' are taking longer than expected.`,
+        `5% of responses from ECS service '${
+          this.serviceName
+        }' are taking longer than the expected duration of ${(
+          props.targetResponseTimeAlarm?.threshold ?? cdk.Duration.millis(500)
+        ).toMilliseconds()} ms.`,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       evaluationPeriods: props.targetResponseTimeAlarm?.evaluationPeriods ?? 1,
       threshold: (


### PR DESCRIPTION
Adds the surpassed threshold value to the generated alarm description for `TargetResponseTimeAlarm`.