### PR TITLE
feat: allow overriding HttpsListener props in LoadBalancer

### DIFF
--- a/src/load-balancer/__tests__/__snapshots__/load-balancer.test.ts.snap
+++ b/src/load-balancer/__tests__/__snapshots__/load-balancer.test.ts.snap
@@ -271,3 +271,288 @@ Object {
   },
 }
 `;
+
+exports[`create load balancer and override TLS configuration 1`] = `
+Object {
+  "Resources": Object {
+    "LoadBalancer8E47CE52": Object {
+      "DependsOn": Array [
+        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
+        "LoadBalancerAccessLogsBucketD82011C7",
+      ],
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "false",
+          },
+          Object {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          Object {
+            "Key": "access_logs.s3.bucket",
+            "Value": Object {
+              "Ref": "LoadBalancerAccessLogsBucketD82011C7",
+            },
+          },
+          Object {
+            "Key": "access_logs.s3.prefix",
+            "Value": "",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerSecurityGroupC89CA14B",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Array [
+          Object {
+            "Fn::ImportValue": "SuuportStack:ExportsOutputRefVpcPublicSubnet1Subnet5C2D37C4FFA2B456",
+          },
+          Object {
+            "Fn::ImportValue": "SuuportStack:ExportsOutputRefVpcPublicSubnet2Subnet691E08A351552740",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerAccessLogsBucketD82011C7": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LifecycleConfiguration": Object {
+          "Rules": Array [
+            Object {
+              "ExpirationInDays": 30,
+              "Status": "Enabled",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "LoadBalancerAccessLogsBucketPolicy6B02AF07": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "LoadBalancerAccessLogsBucketD82011C7",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::897822967062:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerAccessLogsBucketD82011C7",
+                        "Arn",
+                      ],
+                    },
+                    "/AWSLogs/",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "s3:x-amz-acl": "bucket-owner-full-control",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "delivery.logs.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerAccessLogsBucketD82011C7",
+                        "Arn",
+                      ],
+                    },
+                    "/AWSLogs/",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetBucketAcl",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "delivery.logs.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "LoadBalancerAccessLogsBucketD82011C7",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "LoadBalancerDefaultTargetGroup162BFC2A": Object {
+      "Properties": Object {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "VpcId": Object {
+          "Fn::ImportValue": "SuuportStack:ExportsOutputRefVpc8378EB38272D6E3A",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "LoadBalancerHttpListener9DD37EAA": Object {
+      "DependsOn": Array [
+        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
+        "LoadBalancerAccessLogsBucketD82011C7",
+      ],
+      "Properties": Object {
+        "DefaultActions": Array [
+          Object {
+            "RedirectConfig": Object {
+              "Port": "443",
+              "Protocol": "HTTPS",
+              "StatusCode": "HTTP_301",
+            },
+            "Type": "redirect",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancer8E47CE52",
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerHttpsListener68D81C94": Object {
+      "DependsOn": Array [
+        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
+        "LoadBalancerAccessLogsBucketD82011C7",
+      ],
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": Object {
+              "Fn::ImportValue": "SuuportStack:ExportsOutputRefCertificate4E7ABB08F7C8AF50",
+            },
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "LoadBalancerDefaultTargetGroup162BFC2A",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancer8E47CE52",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerSecurityGroupC89CA14B": Object {
+      "DependsOn": Array [
+        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
+        "LoadBalancerAccessLogsBucketD82011C7",
+      ],
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB StackLoadBalancerF0AF61AA",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "VpcId": Object {
+          "Fn::ImportValue": "SuuportStack:ExportsOutputRefVpc8378EB38272D6E3A",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+  },
+}
+`;

--- a/src/load-balancer/__tests__/__snapshots__/load-balancer.test.ts.snap
+++ b/src/load-balancer/__tests__/__snapshots__/load-balancer.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`create load balancer 1`] = `
 Object {
@@ -278,7 +278,6 @@ Object {
     "LoadBalancer8E47CE52": Object {
       "DependsOn": Array [
         "LoadBalancerAccessLogsBucketPolicy6B02AF07",
-        "LoadBalancerAccessLogsBucketD82011C7",
       ],
       "Properties": Object {
         "LoadBalancerAttributes": Array [
@@ -462,10 +461,6 @@ Object {
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "LoadBalancerHttpListener9DD37EAA": Object {
-      "DependsOn": Array [
-        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
-        "LoadBalancerAccessLogsBucketD82011C7",
-      ],
       "Properties": Object {
         "DefaultActions": Array [
           Object {
@@ -486,10 +481,6 @@ Object {
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "LoadBalancerHttpsListener68D81C94": Object {
-      "DependsOn": Array [
-        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
-        "LoadBalancerAccessLogsBucketD82011C7",
-      ],
       "Properties": Object {
         "Certificates": Array [
           Object {
@@ -516,10 +507,6 @@ Object {
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "LoadBalancerSecurityGroupC89CA14B": Object {
-      "DependsOn": Array [
-        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
-        "LoadBalancerAccessLogsBucketD82011C7",
-      ],
       "Properties": Object {
         "GroupDescription": "Automatically created Security Group for ELB StackLoadBalancerF0AF61AA",
         "SecurityGroupEgress": Array [

--- a/src/load-balancer/__tests__/load-balancer.test.ts
+++ b/src/load-balancer/__tests__/load-balancer.test.ts
@@ -5,6 +5,7 @@ import * as route53 from "aws-cdk-lib/aws-route53"
 import { App, Stack } from "aws-cdk-lib"
 import "jest-cdk-snapshot"
 import { LoadBalancer } from ".."
+import { SslPolicy } from "aws-cdk-lib/aws-elasticloadbalancingv2"
 
 test("create load balancer", () => {
   const app = new App()
@@ -34,6 +35,44 @@ test("create load balancer", () => {
   new LoadBalancer(stack, "LoadBalancer", {
     certificates: [certificate],
     vpc: vpc,
+  })
+
+  expect(stack).toMatchCdkSnapshot()
+})
+
+test("create load balancer and override TLS configuration", () => {
+  const app = new App()
+
+  const supportStack = new Stack(app, "SuuportStack", {
+    env: {
+      region: "eu-north-1",
+    },
+  })
+
+  const stack = new Stack(app, "Stack", {
+    env: {
+      region: "eu-north-1",
+    },
+  })
+
+  const vpc = new ec2.Vpc(supportStack, "Vpc")
+
+  const hostedZone = new route53.HostedZone(supportStack, "HostedZone", {
+    zoneName: "2.example.com",
+  })
+
+  const certificate = new cm.Certificate(supportStack, "Certificate", {
+    domainName: `*.2.example.com`,
+    subjectAlternativeNames: ["2.example.com"],
+    validation: cm.CertificateValidation.fromDns(hostedZone),
+  })
+
+  new LoadBalancer(stack, "LoadBalancer", {
+    certificates: [certificate],
+    vpc: vpc,
+    overrideHttpsListenerProps: {
+      sslPolicy: SslPolicy.RECOMMENDED_TLS,
+    },
   })
 
   expect(stack).toMatchCdkSnapshot()

--- a/src/load-balancer/load-balancer.ts
+++ b/src/load-balancer/load-balancer.ts
@@ -10,6 +10,7 @@ export interface LoadBalancerProps {
   certificates: certificatemanager.ICertificate[]
   vpc: ec2.IVpc
   overrideLoadBalancerProps?: Partial<elb.ApplicationLoadBalancerProps>
+  overrideHttpsListenerProps?: Partial<elb.BaseApplicationListenerProps>
 }
 
 export class LoadBalancer extends constructs.Construct {
@@ -64,6 +65,7 @@ export class LoadBalancer extends constructs.Construct {
       port: 443,
       certificates: props.certificates,
       defaultTargetGroups: [defaultTargetGroup],
+      ...props.overrideHttpsListenerProps,
     })
 
     this.accessLogsBucket = new s3.Bucket(this, "AccessLogsBucket", {


### PR DESCRIPTION
Standardverdi bør være `SslPolicy.RECOMMENDED_TLS`, men frem til vi er enige om det så kan prosjektene selv overstyre.