### PR TITLE
feat: add more context to slack notifications from CDK pipelines

### DIFF
--- a/src/cdk-pipelines/__tests__/slack-notification.test.ts
+++ b/src/cdk-pipelines/__tests__/slack-notification.test.ts
@@ -34,6 +34,7 @@ test("slack-notification", () => {
     pipeline: pipeline.codePipeline,
     slackWebhookUrl: "https://hooks.slack.com/services/abc",
     slackChannel: "#test-other",
+    artifactsBucket: pipeline.artifactsBucket,
     singletonLambdaUuid: "f0d7e25c-8247-48bb-beb4-5b1d8ff91f30",
   })
 

--- a/src/cdk-pipelines/slack-notification.ts
+++ b/src/cdk-pipelines/slack-notification.ts
@@ -5,12 +5,17 @@ import * as iam from "aws-cdk-lib/aws-iam"
 import * as lambda from "aws-cdk-lib/aws-lambda"
 import * as cdk from "aws-cdk-lib"
 import * as path from "path"
+import * as s3 from "aws-cdk-lib/aws-s3"
 
 export interface SlackNotificationProps {
   /**
    * CodePipeline to monitor.
    */
   pipeline: codepipeline.IPipeline
+  /**
+   * Artifacts bucket used by pipeline
+   */
+  artifactsBucket: s3.IBucket
   /**
    * Slack webhook URL.
    */
@@ -20,18 +25,27 @@ export interface SlackNotificationProps {
    */
   slackChannel: string
   /**
-   * @default no description
+   * An optional friendly name that will be used in the Slack notifications instead of the AWS account ID
    */
-  accountGroupName?: string
+  accountFriendlyName?: string
   /**
-   * @default no description
+   * Control the amount and types of notifications being sent to Slack.
+   * "WARN" is the least verbose, while "DEBUG" is the most verbose.
+   *
+   * "WARN" - Includes notifications related to the failure of a pipeline execution.
+   * "INFO" - Adds notifications for the success of a pipeline execution.
+   * "DEBUG" - Adds notifications for the start and superseding of a pipeline execution.
+   *
+   * @default "WARN"
    */
-  accountDescription?: string
+  notificationLevel?: "WARN" | "INFO" | "DEBUG"
   /**
-   * @default false
+   * The key of the object (e.g., `my-prefix/my-file.json`) that triggers the S3 Source Action associated with the pipeline.
+   * By configuring this parameter you can specify which objects the Lambda function that sends messages to Slack can access in the artifacts bucket.
+   *
+   * @default - the Lambda function can read all objects in the artifacts bucket.
    */
-  alwaysShowSucceeded?: boolean
-
+  triggerObjectKey?: string
   /**
    * Used to control that only one lambda is created in the account.
    *
@@ -59,15 +73,11 @@ export class SlackNotification extends constructs.Construct {
     const environment: Record<string, string> = {
       SLACK_URL: props.slackWebhookUrl,
       SLACK_CHANNEL: props.slackChannel,
-      ALWAYS_SHOW_SUCCEEDED: String(props.alwaysShowSucceeded ?? false),
+      NOTIFICATION_LEVEL: props.notificationLevel ?? "WARN",
     }
 
-    if (props.accountGroupName != null) {
-      environment.ACCOUNT_GROUP_NAME = props.accountGroupName
-    }
-
-    if (props.accountDescription != null) {
-      environment.ACCOUNT_DESC = props.accountDescription
+    if (props.accountFriendlyName != null) {
+      environment.ACCOUNT_FRIENDLY_NAME = props.accountFriendlyName
     }
 
     const reportFunction = new lambda.SingletonFunction(this, "Function", {
@@ -76,7 +86,7 @@ export class SlackNotification extends constructs.Construct {
         path.join(__dirname, "../../assets/pipeline-slack-notification-lambda"),
       ),
       handler: "index.handler",
-      runtime: lambda.Runtime.PYTHON_3_8,
+      runtime: lambda.Runtime.PYTHON_3_11,
       timeout: cdk.Duration.seconds(10),
       environment,
       description:
@@ -93,11 +103,13 @@ export class SlackNotification extends constructs.Construct {
       }),
     )
 
+    props.artifactsBucket.grantRead(reportFunction, props.triggerObjectKey)
+
     props.pipeline.onStateChange("Event" + (props.singletonLambdaUuid ?? ""), {
       eventPattern: {
         detail: {
           // Available states: https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html
-          state: ["SUCCEEDED", "FAILED"],
+          state: ["SUCCEEDED", "FAILED", "STARTED", "SUPERSEDED"],
         },
       },
       target: new eventsTargets.LambdaFunction(reportFunction),


### PR DESCRIPTION
This commit adds more context to Slack notifications from CDK pipelines, which are sent based upon status change events in CDK pipelines.

1. All Slack notifications from CDK pipelines include the execution ID from CodePipeline
2. If metadata is sent from CI in the trigger file, notifications will include information about which **branch** and **repo** CD was triggered from. They will also include the **commit hash** and **commit author**. 
3. Consuments can set the `notificationLevel` prop when configuring Slack notification through `addSlackNotification` to express which event types should be sent to Slack. **WARN** includes notifications related to the failure of a pipeline execution. **INFO** adds notifications for the success of a pipeline execution. **DEBUG** adds notifications for the start and superseding of a pipeline execution.

**Breaking changes for consuments:**
1. This PR removes the `alwaysShowSucceeded` prop that could previously be sent in to `addSlackNotification` to indicate that notifications should be sent for the success of a pipeline execution. Use `notificationLevel` instead.
2. This PR removes the `accountGroupName` and  `accountDescription` props that could previously be sent in to `addSlackNotification`. Use  accountFriendlyName instead to indicate a name for the pipeline.