### PR TITLE
Remove deprecated feature flag

### DIFF
--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -27,21 +27,7 @@ interface FeatureFlagInfo {
 }
 
 // Custom feature flags for liflig-cdk
-/**
- * @deprecated No longer in use, this is now the default behaviour.
- */
-export const FEATURE_FLAG_CDK_PIPELINES_SPEED_UP =
-  "@liflig-cdk/cdk-pipelines:enableExperimentalSpeedUp"
-
-const FLAGS: { [key: string]: FeatureFlagInfo } = {
-  [FEATURE_FLAG_CDK_PIPELINES_SPEED_UP]: {
-    default: true,
-    description:
-      "Reduce execution time of CDK Pipelines by making various tweaks (e.g., skip creation of CloudFormation changesets, disable CodePipeline S3 polling).",
-    deprecationReason:
-      "This feature flag is no longer in use, this is now the default behaviour.",
-  },
-}
+const FLAGS: { [key: string]: FeatureFlagInfo } = {}
 
 const getFeatureFlagDefault = (flagName: string) => {
   return FLAGS[flagName]?.default ?? false


### PR DESCRIPTION
Removes the unused feature flag, but lets the structure for adding flags later remain.