### PR TITLE
List all active alarms when notifying slack

### DIFF
--- a/assets/slack-alarm-lambda/index.py
+++ b/assets/slack-alarm-lambda/index.py
@@ -6,6 +6,7 @@ from urllib.error import URLError, HTTPError
 import boto3
 
 secrets_manager = boto3.client("secretsmanager")
+cloudwatch = boto3.client("cloudwatch")
 
 SLACK_URL_SECRET_NAME = os.getenv("SLACK_URL_SECRET_NAME", None)
 PROJECT_NAME = os.getenv("PROJECT_NAME", "undefined")
@@ -15,9 +16,24 @@ ENVIRONMENT_NAME = os.getenv("ENVIRONMENT_NAME", "undefined")
 def handler(event, context):
     print("Event: " + json.dumps(event))
     message = json.loads(event["Records"][0]["Sns"]["Message"])
-    region = event["Records"][0]["Sns"]["TopicArn"].split(":")[3]
+    topic_arn = event["Records"][0]["Sns"]["TopicArn"]
+    region = topic_arn.split(":")[3]
 
-    return send_slack_notification(message, region)
+    active_alarms = list_all_active_alarms(topic_arn)
+    return send_slack_notification(message, region, active_alarms)
+
+
+def list_all_active_alarms(topic_arn: str) -> list[str]:
+    try:
+        response: dict = cloudwatch.describe_alarms(AlarmTypes=["CompositeAlarm", "MetricAlarm"],
+                                                    StateValue="ALARM",
+                                                    ActionPrefix=topic_arn)
+        all_alarms = response["CompositeAlarms"] + response["MetricAlarms"]
+        names: list[str] = [alarm["AlarmName"] for alarm in all_alarms if alarm["ActionsEnabled"]]
+        return names
+    except Exception as e:
+        print(f"Failed to list alarms: {e}")
+        return []
 
 
 def get_masked_slack_webhook_url(slack_webhook_url: str):
@@ -37,7 +53,7 @@ def get_secret(secret):
         raise Exception(f"Error retrieving secret: {e}")
 
 
-def send_slack_notification(message, region):
+def send_slack_notification(message: str, region: str, active_alarms: list[str]):
     alarm_emojis = {
         "ALARM": ":rotating_light:",
         "INSUFFICIENT_DATA": ":warning:",
@@ -52,9 +68,9 @@ def send_slack_notification(message, region):
         {
             "color": color,
             "title_link": "https://console.aws.amazon.com/cloudwatch/home?region="
-            + region
-            + "#alarm:alarmFilter=ANY;name="
-            + message["AlarmName"],
+                          + region
+                          + "#alarm:alarmFilter=ANY;name="
+                          + message["AlarmName"],
             "fallback": f"{alarm_emojis.get(message['NewStateValue'], '')} {message['AlarmName']}: {alarm_description}",
             "fields": [
                 {"title": "Alarm Name", "value": message["AlarmName"], "short": False},
@@ -70,18 +86,23 @@ def send_slack_notification(message, region):
                 {
                     "title": "State Transition",
                     "value": message.get("OldStateValue", "Unknown")
-                    + " -> "
-                    + message["NewStateValue"],
+                             + " -> "
+                             + message["NewStateValue"],
                     "short": False,
                 },
                 {
                     "title": "Link to Alarm",
                     "value": "https://console.aws.amazon.com/cloudwatch/home?region="
-                    + region
-                    + "#alarm:alarmFilter=ANY;name="
-                    + message["AlarmName"],
+                             + region
+                             + "#alarm:alarmFilter=ANY;name="
+                             + message["AlarmName"],
                     "short": False,
                 },
+                {
+                    "title": "All active alarms " + (alarm_emojis["ALARM"] if len(active_alarms) else ""),
+                    "value": "\n".join(["- " + alarm for alarm in active_alarms]) if len(active_alarms) else "None",
+                    "short": False,
+                }
             ],
         }
     ]

--- a/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
@@ -13,7 +13,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "c0d25018481918152e92fa9c210f22d56dbfa1e1ebc8bb1852b4482555f64368.zip",
+          "S3Key": "d9fa0c922ce4bc8129ffc5b4336a9215994c76b4b61b0364801d607df00d774b.zip",
         },
         "Description": "Receives CloudWatch Alarms through SNS and sends a formatted version to Slack",
         "Environment": Object {
@@ -118,6 +118,11 @@ Object {
               "Resource": Object {
                 "Ref": "TestSecret16AF87B1",
               },
+            },
+            Object {
+              "Action": "cloudwatch:DescribeAlarms",
+              "Effect": "Allow",
+              "Resource": "*",
             },
           ],
           "Version": "2012-10-17",

--- a/src/alarms/slack-alarm.ts
+++ b/src/alarms/slack-alarm.ts
@@ -1,6 +1,7 @@
 import * as constructs from "constructs"
 import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions"
 import * as iam from "aws-cdk-lib/aws-iam"
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam"
 import * as lambda from "aws-cdk-lib/aws-lambda"
 import * as sns from "aws-cdk-lib/aws-sns"
 import { Duration } from "aws-cdk-lib"
@@ -59,6 +60,13 @@ export class SlackAlarm extends constructs.Construct {
       principal: new iam.ServicePrincipal("sns.amazonaws.com"),
       sourceArn: this.alarmTopic.topicArn,
     })
+    slackLambda.addToRolePolicy(
+      new PolicyStatement({
+        actions: ["cloudwatch:DescribeAlarms"],
+        effect: Effect.ALLOW,
+        resources: ["*"],
+      }),
+    )
 
     new sns.Subscription(this, "Subscription", {
       endpoint: slackLambda.functionArn,


### PR DESCRIPTION
Adds a new section with
```
All active alarms :siren:
- europris-prod-fiftytwo-pos-adapter-master-ingress-dlq-too-many-messages-exist-1-alarm
- europris-prod-m3-b2bcredit-adapter-ingress-dlq-too-many-messages-exist-1-alarm
```

<img width="692" alt="image" src="https://github.com/capralifecycle/liflig-cdk/assets/7364831/f3d30a2a-a93f-423b-b665-7b583e1a52e1">

<img width="614" alt="image" src="https://github.com/capralifecycle/liflig-cdk/assets/7364831/47d3e35a-5fed-4014-8465-e150f1e2ce0e">
