### PR TITLE
Add circuit breakers to Fargate service

### DIFF
--- a/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
+++ b/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
@@ -75,6 +75,10 @@ Object {
             "Enable": false,
             "Rollback": false,
           },
+          "DeploymentCircuitBreaker": Object {
+            "Enable": true,
+            "Rollback": true,
+          },
           "MaximumPercent": 200,
           "MinimumHealthyPercent": 100,
         },

--- a/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
+++ b/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
@@ -75,10 +75,6 @@ Object {
             "Enable": false,
             "Rollback": false,
           },
-          "DeploymentCircuitBreaker": Object {
-            "Enable": true,
-            "Rollback": true,
-          },
           "MaximumPercent": 200,
           "MinimumHealthyPercent": 100,
         },

--- a/src/ecs/__tests__/fargate-service.test.ts
+++ b/src/ecs/__tests__/fargate-service.test.ts
@@ -78,6 +78,7 @@ test("creates fargate service with parameters and listener rule", () => {
       ecrRepository,
       "exampleEcrTag",
     ),
+    enableCircuitBreaker: true,
   })
 
   new ListenerRule(stack, "Dns", {

--- a/src/ecs/fargate-service.ts
+++ b/src/ecs/fargate-service.ts
@@ -78,7 +78,7 @@ export class FargateService extends constructs.Construct {
 
     /**
      * Set this flag to disable this stack creating a completely new service and attempting replace when enabling circuit breakers
-     * Mitigating the deploytment error: 'a service with the name <...> already exists'
+     * Mitigating the deployment error: 'a service with the name <...> already exists'
      * See: github.com/aws/aws-cdk/pull/22467
      */
     this.node.setContext(

--- a/src/ecs/fargate-service.ts
+++ b/src/ecs/fargate-service.ts
@@ -56,6 +56,10 @@ export interface FargateServiceProps {
    * @default false
    */
   skipTargetGroup?: boolean
+  /**
+   * @default true
+   */
+  enableCircuitBreaker?: boolean
 }
 
 export class FargateService extends constructs.Construct {
@@ -71,6 +75,16 @@ export class FargateService extends constructs.Construct {
     props: FargateServiceProps,
   ) {
     super(scope, id)
+
+    /**
+     * Set this flag to disable this stack creating a completely new service and attempting replace when enabling circuit breakers
+     * Mitigating the deploytment error: 'a service with the name <...> already exists'
+     * See: github.com/aws/aws-cdk/pull/22467
+     */
+    this.node.setContext(
+      "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker",
+      true,
+    )
 
     const parameters = new ConfigureParameters(this, {
       ssmPrefix: `/liflig-cdk/${cdk.Stack.of(this).stackName}/${
@@ -125,6 +139,8 @@ export class FargateService extends constructs.Construct {
       hostPort: port,
     })
 
+    const enableCircuitBreaker = props.enableCircuitBreaker ?? true
+
     this.fargateService = new ecs.FargateService(this, "Service", {
       serviceName: props.serviceName,
       vpcSubnets: {
@@ -139,6 +155,12 @@ export class FargateService extends constructs.Construct {
       securityGroups: [this.securityGroup],
       platformVersion: ecs.FargatePlatformVersion.VERSION1_4,
       enableExecuteCommand: true,
+      circuitBreaker: enableCircuitBreaker
+        ? {
+            enable: true,
+            rollback: true,
+          }
+        : undefined,
       ...props.overrideFargateServiceProps,
     })
 

--- a/src/ecs/fargate-service.ts
+++ b/src/ecs/fargate-service.ts
@@ -57,7 +57,7 @@ export interface FargateServiceProps {
    */
   skipTargetGroup?: boolean
   /**
-   * @default true
+   * @default false
    */
   enableCircuitBreaker?: boolean
 }
@@ -139,7 +139,7 @@ export class FargateService extends constructs.Construct {
       hostPort: port,
     })
 
-    const enableCircuitBreaker = props.enableCircuitBreaker ?? true
+    const enableCircuitBreaker = props.enableCircuitBreaker ?? false
 
     this.fargateService = new ecs.FargateService(this, "Service", {
       serviceName: props.serviceName,


### PR DESCRIPTION
### Context

Adds better support for using circuit breakers with the fargate service to prevent boot-loops in ecs. 

### Description

This change adds an  option for enabling circuit breakers for the Fargate service. In addition to enabling a feature flag which stops the service from being replaced when using enabling circuit breakers when no  deployment controller was previously defined.

### Testing

The circuit breaker is toggled on for the tests being added to the snapshots.

### Audience

Looks to be both CargoNet and Tomler at the moment, but might be beneficial for more teams in the future in addition to enabling the circuit breakers by default to prevent bootloops.
