### PR TITLE
fix: composite ecs service alarm should not have disabled actions

### DIFF
--- a/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/service-alarms.test.ts.snap
@@ -137,7 +137,6 @@ Object {
     },
     "ServiceAlarmsTargetHealthAlarm18599060": Object {
       "Properties": Object {
-        "ActionsEnabled": false,
         "AlarmActions": Array [
           Object {
             "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",

--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -248,7 +248,6 @@ export class ServiceAlarms extends constructs.Construct {
         alarmDescription:
           props.targetHealthAlarm?.description ??
           `The load balancer is either receiving bad health checks from or is unable to connect to target(s) in ECS service '${this.serviceName}'`,
-        actionsEnabled: false,
       },
     )
     if (props.targetHealthAlarm?.enabled ?? true) {


### PR DESCRIPTION
For contribution guidelines, see `CONTRIBUTING.md`.

### Context

_Which problem do these changes solve?_
Bug. The actions of the composite alarm are never enabled even though alarm actions are added. The client would expect alarm actions to be enabled unless explicitly disabled. This basically makes the alarm useless.

### Description

_What are the changes?_
Remove flag that disables alarm actions on composite alarm

### Testing

_How will the changes be tested?_
Verified via changes in snapshot

### Audience

_Which teams currently needs these changes?_
Team Tomler. Also affects Europris

### Scope of impact

_Which consumers will this change affect?_
NMD, Europris
