### PR TITLE
feat(api-gw): support alternate credential secret format

### DIFF
--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -1029,7 +1029,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "2b7d714ade3a69ba5ce253b1669c8cc970ab6097c232fddb209a226abf167ab1.zip",
+          "S3Key": "f30c6a29e8e7ba0e9623f83c716fb2c20ee2a00d566758b4b9704e920bc2f68e.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {
@@ -1939,7 +1939,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "85be47d0894118a21a6deec68ab9fcf19541ac2b59a070df0d73b19c97d400b1.zip",
+          "S3Key": "f32a280b8c8d745b8eb16fa89f8170152d407c4e6c13947fb9744f71eb2847a7.zip",
         },
         "Environment": Object {
           "Variables": Object {
@@ -2884,7 +2884,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b91c855455d2611c83a3ea820a174d6ceabe1079f28a5f7ecc79dc58e0728a3.zip",
+          "S3Key": "358ca55a079ce8e652fcbad2dec2364f9e744c5cdd01576061a6026c4cbc18e4.zip",
         },
         "Environment": Object {
           "Variables": Object {

--- a/src/api-gateway/authorizer-lambdas/basic-auth-authorizer.ts
+++ b/src/api-gateway/authorizer-lambdas/basic-auth-authorizer.ts
@@ -4,7 +4,9 @@
  *
  * Expects the following environment variables:
  * - CREDENTIALS_SECRET_NAME
- *   - Secret value should follow this format: `{"username":"<username>","password":"<password>"}`
+ *   - Secret value should follow this format: `{"username":"<username>","password":"<password>"}`.
+ *     A different format with an array of pre-encoded credentials is also supported - see docs for
+ *     the `BasicAuthAuthorizerProps` on the `ApiGateway` construct.
  */
 
 import type {
@@ -21,16 +23,26 @@ export const handler = async (
     return { isAuthorized: false }
   }
 
-  const expectedAuthHeader = await getExpectedAuthHeader()
+  const expectedAuthHeaders = await getExpectedBasicAuthHeaders()
 
-  return { isAuthorized: authHeader === expectedAuthHeader }
+  for (const expectedHeader of expectedAuthHeaders) {
+    if (authHeader === expectedHeader) {
+      return { isAuthorized: true }
+    }
+  }
+
+  return { isAuthorized: false }
 }
 
 /** Cache this value, so that subsequent lambda invocations don't have to refetch. */
-let cachedAuthHeader: string | undefined = undefined
+let cachedBasicAuthHeaders: string[] | undefined = undefined
 
-async function getExpectedAuthHeader(): Promise<string> {
-  if (cachedAuthHeader === undefined) {
+/**
+ * Returns an array of allowed basic auth headers, to support credential secrets with multiple
+ * values (see `BasicAuthAuthorizerProps` on the `ApiGateway` construct for more on this).
+ */
+async function getExpectedBasicAuthHeaders(): Promise<string[]> {
+  if (cachedBasicAuthHeaders === undefined) {
     const secretName: string | undefined =
       process.env["CREDENTIALS_SECRET_NAME"]
     if (!secretName) {
@@ -38,27 +50,49 @@ async function getExpectedAuthHeader(): Promise<string> {
       throw new Error()
     }
 
-    cachedAuthHeader = await getSecretAsBasicAuthHeader(secretName)
+    cachedBasicAuthHeaders = await getSecretAsBasicAuthHeaders(secretName)
   }
 
-  return cachedAuthHeader
+  return cachedBasicAuthHeaders
 }
 
-async function getSecretAsBasicAuthHeader(secretName: string): Promise<string> {
-  const credentials = await getSecretValue(secretName)
-  if (!secretHasExpectedFormat(credentials)) {
-    console.error(
-      `Basic auth credentials secret did not follow expected format (secret name: '${secretName}')`,
-    )
-    throw new Error()
+async function getSecretAsBasicAuthHeaders(
+  secretName: string,
+): Promise<string[]> {
+  const secret = await getSecretValue(secretName)
+
+  if (isSingleUsernameAndPassword(secret)) {
+    const header =
+      "Basic " +
+      Buffer.from(`${secret.username}:${secret.password}`).toString("base64")
+    return [header]
   }
 
-  return (
-    "Basic " +
-    Buffer.from(`${credentials.username}:${credentials.password}`).toString(
-      "base64",
-    )
+  // See `BasicAuthAuthorizerProps` on the `ApiGateway` construct for an explanation of the formats
+  // we parse here
+  if (hasCredentialsKeyWithStringValue(secret)) {
+    let credentialsArray: unknown
+    try {
+      credentialsArray = JSON.parse(secret.credentials)
+    } catch (e) {
+      console.error(
+        `Failed to parse credentials array in secret '${secretName}' as JSON`,
+        e,
+      )
+      throw new Error()
+    }
+
+    if (isStringArray(credentialsArray)) {
+      return credentialsArray.map(
+        (encodedCredential) => `Basic ${encodedCredential}`,
+      )
+    }
+  }
+
+  console.error(
+    `Basic auth credentials secret did not follow any expected format (secret name: '${secretName}')`,
   )
+  throw new Error()
 }
 
 /** For overriding dependency creation in tests. */
@@ -75,10 +109,15 @@ async function getSecretValue(secretName: string): Promise<unknown> {
     throw new Error()
   }
 
-  return JSON.parse(secret.SecretString)
+  try {
+    return JSON.parse(secret.SecretString)
+  } catch (e) {
+    console.error(`Failed to parse secret '${secretName}' as JSON`, e)
+    throw new Error()
+  }
 }
 
-function secretHasExpectedFormat(
+function isSingleUsernameAndPassword(
   value: unknown,
 ): value is { username: string; password: string } {
   return (
@@ -89,4 +128,33 @@ function secretHasExpectedFormat(
     "password" in value &&
     typeof value.password === "string"
   )
+}
+
+function hasCredentialsKeyWithStringValue(
+  value: unknown,
+): value is { credentials: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "credentials" in value &&
+    typeof value.credentials === "string"
+  )
+}
+
+function isStringArray(value: unknown): value is string[] {
+  if (!Array.isArray(value)) {
+    return false
+  }
+
+  for (const element of value) {
+    if (typeof element !== "string") {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function clearCache() {
+  cachedBasicAuthHeaders = undefined
 }

--- a/src/api-gateway/authorizer-lambdas/cognito-user-pool-authorizer.ts
+++ b/src/api-gateway/authorizer-lambdas/cognito-user-pool-authorizer.ts
@@ -190,3 +190,8 @@ function secretHasExpectedFormat(
     typeof value.password === "string"
   )
 }
+
+export function clearCache() {
+  cachedTokenVerifier = undefined
+  cachedInternalAuthorizationHeader = undefined
+}

--- a/src/api-gateway/http-api-gateway.ts
+++ b/src/api-gateway/http-api-gateway.ts
@@ -364,7 +364,7 @@ export type CognitoUserPoolAuthorizerProps<
    *
    * The secret value must follow this format:
    * ```json
-   * {"username":"<username>","password":"<password>"}
+   * { "username": "<username>", "password": "<password>" }
    * ```
    *
    * This prop solves the following use-case:
@@ -391,11 +391,27 @@ export type CognitoUserPoolAuthorizerProps<
 
 export type BasicAuthAuthorizerProps = {
   /**
-   * Name of secret in AWS Secrets Manager that stores basic auth credentials. The secret value must
-   * follow this format:
+   * Name of secret in AWS Secrets Manager that stores basic auth credentials. The secret value
+   * should follow this format:
    * ```json
-   * {"username":"<username>","password":"<password>"}
+   * { "username": "<username>", "password": "<password>" }
    * ```
+   *
+   * The following format is also supported:
+   * ```json
+   * { "credentials": "[\"<encoded-credential-1>\",\"<encoded-credential-2>\"]" }
+   * ```
+   * ...consisting of:
+   * - A single key, `credentials`
+   * - With a _string_ value
+   * - Which is a stringified, escaped JSON array of base64-encoded credentials
+   * - In which each element is encoded from `<username>:<password>`
+   *
+   * If the secret is on this format, the authorizer will match the request's Authorization header
+   * against any one of these encoded credentials.
+   *
+   * The reason that this second format stores stringified JSON _inside_ JSON, is due to a
+   * limitation in Liflig's `load-secrets` library, which only allows storing strings values.
    */
   credentialsSecretName: string
 }
@@ -406,11 +422,27 @@ export type CognitoUserPoolOrBasicAuthAuthorizerProps<
   userPool: IUserPool
 
   /**
-   * Name of secret in AWS Secrets Manager that stores basic auth credentials. The secret value must
-   * follow this format:
+   * Name of secret in AWS Secrets Manager that stores basic auth credentials. The secret value
+   * should follow this format:
    * ```json
-   * {"username":"<username>","password":"<password>"}
+   * { "username": "<username>", "password": "<password>" }
    * ```
+   *
+   * The following format is also supported:
+   * ```json
+   * { "credentials": "[\"<encoded-credential-1>\",\"<encoded-credential-2>\"]" }
+   * ```
+   * ...consisting of:
+   * - A single key, `credentials`
+   * - With a _string_ value
+   * - Which is a stringified, escaped JSON array of base64-encoded credentials
+   * - In which each element is encoded from `<username>:<password>`
+   *
+   * If the secret is on this format, the authorizer will match the request's Authorization header
+   * against any one of these encoded credentials.
+   *
+   * The reason that this second format stores stringified JSON _inside_ JSON, is due to a
+   * limitation in Liflig's `load-secrets` library, which only allows storing strings values.
    */
   basicAuthCredentialsSecretName?: string
 


### PR DESCRIPTION
In the current ApiGateway implementation, basic auth credentials must be stored on the following format in Secrets Manager in order for the basic auth authorizer to parse it:
```json
{ "username": "<username>", "password": "<password>" }
```

However, some projects instead store credentials on the following format:
```json
{ "credentials": "[\"<encoded-credential-1>\",\"<encoded-credential-2>\"]" }
```
...consisting of:
- A single key, `credentials`
- With a _string_ value
- Which is a stringified, escaped JSON array of base64-encoded credentials
- In which each element is encoded from `<username>:<password>`

The reason that this second format stores stringified JSON _inside_ JSON, is due to a limitation in Liflig's `load-secrets` library, which only allows storing strings values.

This commit changes the basic auth Lambda authorizer to allow credential secrets on this second format. Tests have been expanded to cover this case for all authorizers.
