### PR TITLE
feat(api-gw): support array of objects as credential secret value

### DIFF
--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -1029,7 +1029,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "b8d7ce9bc500381b4403526ff91f836ed636857533141f340a3b22031bc115ec.zip",
+          "S3Key": "6d6556060ed5077e83fdd69fc4feaf2cb5736fa837267e13f52be0a25ccb7c19.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {
@@ -2884,7 +2884,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "1410ff24fa1f47c25b5443a13116c2138d5aec61e14a4a6b0dd379bd7118f913.zip",
+          "S3Key": "10a6ef34978f57cfabc6471ff5220fbbb9b44a526a0d3004509b5496557bec11.zip",
         },
         "Environment": Object {
           "Variables": Object {

--- a/src/api-gateway/http-api-gateway.ts
+++ b/src/api-gateway/http-api-gateway.ts
@@ -391,27 +391,30 @@ export type CognitoUserPoolAuthorizerProps<
 
 export type BasicAuthAuthorizerProps = {
   /**
-   * Name of secret in AWS Secrets Manager that stores basic auth credentials. The secret value
-   * should follow this format:
-   * ```json
-   * { "username": "<username>", "password": "<password>" }
-   * ```
+   * Name of secret in AWS Secrets Manager that stores basic auth credentials.
    *
-   * The following format is also supported:
-   * ```json
-   * { "credentials": "[\"<encoded-credential-1>\",\"<encoded-credential-2>\"]" }
-   * ```
-   * ...consisting of:
-   * - A single key, `credentials`
-   * - With a _string_ value
-   * - Which is a stringified, escaped JSON array of base64-encoded credentials
-   * - In which each element is encoded from `<username>:<password>`
+   * The following formats are supported for the secret value:
+   * - Single username and password:
+   *   ```json
+   *   { "username": "<username>", "password": "<password>" }
+   *   ```
+   * - Array of username + password objects:
+   *   ```json
+   *   { "credentials": "[{\"username\":\"<user-1>\",\"password\":\"password-1\"},{\"username\":\"<user-2>\",\"password\":\"<password-2>\"}]" }
+   *   ```
+   *   - The value of the `credentials` field is a string, with a stringified, escaped JSON array of
+   *     objects with `username` and `password` fields.
+   *   - The reason that this second format stores stringified JSON _inside_ JSON, is due to a
+   *     limitation in Liflig's `load-secrets` library, which only allows storing string values.
+   * - Array of base64-encoded credentials:
+   *   ```json
+   *   { "credentials": "[\"<encoded-credential-1>\",\"<encoded-credential-2>\"]" }
+   *   ```
+   *   - Each element is encoded from `<username>:<password>`.
+   *   - The array is stringified for the same reason as above.
    *
-   * If the secret is on this format, the authorizer will match the request's Authorization header
-   * against any one of these encoded credentials.
-   *
-   * The reason that this second format stores stringified JSON _inside_ JSON, is due to a
-   * limitation in Liflig's `load-secrets` library, which only allows storing strings values.
+   * If the secret uses one of the array formats, the authorizer will match the request's
+   * Authorization header against any one of the credentials.
    */
   credentialsSecretName: string
 }
@@ -422,27 +425,9 @@ export type CognitoUserPoolOrBasicAuthAuthorizerProps<
   userPool: IUserPool
 
   /**
-   * Name of secret in AWS Secrets Manager that stores basic auth credentials. The secret value
-   * should follow this format:
-   * ```json
-   * { "username": "<username>", "password": "<password>" }
-   * ```
+   * Name of secret in AWS Secrets Manager that stores basic auth credentials.
    *
-   * The following format is also supported:
-   * ```json
-   * { "credentials": "[\"<encoded-credential-1>\",\"<encoded-credential-2>\"]" }
-   * ```
-   * ...consisting of:
-   * - A single key, `credentials`
-   * - With a _string_ value
-   * - Which is a stringified, escaped JSON array of base64-encoded credentials
-   * - In which each element is encoded from `<username>:<password>`
-   *
-   * If the secret is on this format, the authorizer will match the request's Authorization header
-   * against any one of these encoded credentials.
-   *
-   * The reason that this second format stores stringified JSON _inside_ JSON, is due to a
-   * limitation in Liflig's `load-secrets` library, which only allows storing strings values.
+   * See {@link BasicAuthAuthorizerProps.credentialsSecretName} for the supported formats.
    */
   basicAuthCredentialsSecretName?: string
 


### PR DESCRIPTION
#301 added support for a credentials secret format with an array of pre-encoded credentials (for the API Gateway basic auth authorizer). After discussing with @krissrex, we decided that we should also support a format that's not pre-encoded (i.e., an array of objects with `username` and `password` fields, consistent with our single username and password format).

Tests have been expanded to cover this new secret format for all relevant authorizers.