### PR TITLE
feat(api-gw): add support for eventbridge integration

### DIFF
--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -803,21 +803,21 @@ Object {
       },
       "Type": "AWS::Events::EventBus",
     },
-    "TestEventBusApiGatewayAccessLogsAccessLogGroup98D2D6F0": Object {
+    "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "RetentionInDays": 180,
         "Tags": Array [
           Object {
             "Key": "service",
-            "Value": "my-test-eventbus-api",
+            "Value": "my-test-eventbridge-api",
           },
         ],
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
     },
-    "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole3DAA3EAC": Object {
+    "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole96DE390C": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -848,13 +848,13 @@ Object {
         "Tags": Array [
           Object {
             "Key": "service",
-            "Value": "my-test-eventbus-api",
+            "Value": "my-test-eventbridge-api",
           },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicy7F97823D": Object {
+    "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicyA1E30C6D": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -866,7 +866,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "TestEventBusApiGatewayAccessLogsAccessLogGroup98D2D6F0",
+                  "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC",
                   "Arn",
                 ],
               },
@@ -874,16 +874,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicy7F97823D",
+        "PolicyName": "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicyA1E30C6D",
         "Roles": Array [
           Object {
-            "Ref": "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole3DAA3EAC",
+            "Ref": "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole96DE390C",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TestEventBusApiGatewayApiGwToEventBusServiceRole9DEF465C": Object {
+    "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -914,13 +914,13 @@ Object {
         "Tags": Array [
           Object {
             "Key": "service",
-            "Value": "my-test-eventbus-api",
+            "Value": "my-test-eventbridge-api",
           },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "TestEventBusApiGatewayApiGwToEventBusServiceRoleDefaultPolicy70DAC53B": Object {
+    "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDefaultPolicy405989BF": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -937,39 +937,39 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "TestEventBusApiGatewayApiGwToEventBusServiceRoleDefaultPolicy70DAC53B",
+        "PolicyName": "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDefaultPolicy405989BF",
         "Roles": Array [
           Object {
-            "Ref": "TestEventBusApiGatewayApiGwToEventBusServiceRole9DEF465C",
+            "Ref": "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0": Object {
+    "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076": Object {
       "Properties": Object {
-        "DomainName": "my-test-eventbus-api.example.com",
+        "DomainName": "my-test-eventbridge-api.example.com",
         "DomainNameConfigurations": Array [
           Object {
             "CertificateArn": Object {
-              "Ref": "TestEventBusApiGatewayCustomDomainHttpsCertificateBB4C14EF",
+              "Ref": "TestEventBridgeApiGatewayCustomDomainHttpsCertificate0EDD7C1B",
             },
             "EndpointType": "REGIONAL",
             "SecurityPolicy": "TLS_1_2",
           },
         ],
         "Tags": Object {
-          "service": "my-test-eventbus-api",
+          "service": "my-test-eventbridge-api",
         },
       },
       "Type": "AWS::ApiGatewayV2::DomainName",
     },
-    "TestEventBusApiGatewayCustomDomainHttpsCertificateBB4C14EF": Object {
+    "TestEventBridgeApiGatewayCustomDomainHttpsCertificate0EDD7C1B": Object {
       "Properties": Object {
-        "DomainName": "my-test-eventbus-api.example.com",
+        "DomainName": "my-test-eventbridge-api.example.com",
         "DomainValidationOptions": Array [
           Object {
-            "DomainName": "my-test-eventbus-api.example.com",
+            "DomainName": "my-test-eventbridge-api.example.com",
             "HostedZoneId": Object {
               "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
             },
@@ -978,29 +978,29 @@ Object {
         "Tags": Array [
           Object {
             "Key": "Name",
-            "Value": "Stack/TestEventBusApiGateway/CustomDomain/HttpsCertificate",
+            "Value": "Stack/TestEventBridgeApiGateway/CustomDomain/HttpsCertificate",
           },
           Object {
             "Key": "service",
-            "Value": "my-test-eventbus-api",
+            "Value": "my-test-eventbridge-api",
           },
         ],
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
     },
-    "TestEventBusApiGatewayCustomDomainRoute53ARecordApigwAlias834BD48C": Object {
+    "TestEventBridgeApiGatewayCustomDomainRoute53ARecordApigwAlias02B67FD3": Object {
       "Properties": Object {
         "AliasTarget": Object {
           "DNSName": Object {
             "Fn::GetAtt": Array [
-              "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+              "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
               "RegionalDomainName",
             ],
           },
           "HostedZoneId": Object {
             "Fn::GetAtt": Array [
-              "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+              "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
               "RegionalHostedZoneId",
             ],
           },
@@ -1008,15 +1008,15 @@ Object {
         "HostedZoneId": Object {
           "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
         },
-        "Name": "my-test-eventbus-api.example.com.",
+        "Name": "my-test-eventbridge-api.example.com.",
         "Type": "A",
       },
       "Type": "AWS::Route53::RecordSet",
     },
-    "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaBECC85A6": Object {
+    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE": Object {
       "DependsOn": Array [
-        "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy0C859BB9",
-        "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4",
+        "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8",
+        "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
       ],
       "Properties": Object {
         "Code": Object {
@@ -1034,7 +1034,7 @@ Object {
         "Handler": "index.handler",
         "Role": Object {
           "Fn::GetAtt": Array [
-            "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4",
+            "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
             "Arn",
           ],
         },
@@ -1042,13 +1042,13 @@ Object {
         "Tags": Array [
           Object {
             "Key": "service",
-            "Value": "my-test-eventbus-api",
+            "Value": "my-test-eventbridge-api",
           },
         ],
       },
       "Type": "AWS::Lambda::Function",
     },
-    "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4": Object {
+    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1079,13 +1079,13 @@ Object {
         "Tags": Array [
           Object {
             "Key": "service",
-            "Value": "my-test-eventbus-api",
+            "Value": "my-test-eventbridge-api",
           },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy0C859BB9": Object {
+    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -1115,31 +1115,31 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy0C859BB9",
+        "PolicyName": "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8",
         "Roles": Array [
           Object {
-            "Ref": "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4",
+            "Ref": "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843": Object {
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC": Object {
       "Properties": Object {
-        "Description": "An HTTP API for my-test-eventbus-api.example.com.",
+        "Description": "An HTTP API for my-test-eventbridge-api.example.com.",
         "DisableExecuteApiEndpoint": true,
-        "Name": "HttpApi-my-test-eventbus-api",
+        "Name": "HttpApi-my-test-eventbridge-api",
         "ProtocolType": "HTTP",
         "Tags": Object {
-          "service": "my-test-eventbus-api",
+          "service": "my-test-eventbridge-api",
         },
       },
       "Type": "AWS::ApiGatewayV2::Api",
     },
-    "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D9DBA27": Object {
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
         },
         "AuthorizerPayloadFormatVersion": "2.0",
         "AuthorizerResultTtlInSeconds": 1800,
@@ -1155,7 +1155,7 @@ Object {
               ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
               Object {
                 "Fn::GetAtt": Array [
-                  "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaBECC85A6",
+                  "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE",
                   "Arn",
                 ],
               },
@@ -1171,22 +1171,22 @@ Object {
       },
       "Type": "AWS::ApiGatewayV2::Authorizer",
     },
-    "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultStageEED9902C": Object {
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStage58B6C162": Object {
       "DependsOn": Array [
-        "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+        "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
       ],
       "Properties": Object {
         "AccessLogSettings": Object {
           "DestinationArn": Object {
             "Fn::GetAtt": Array [
-              "TestEventBusApiGatewayAccessLogsAccessLogGroup98D2D6F0",
+              "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC",
               "Arn",
             ],
           },
           "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"userAgent\\":\\"$context.identity.userAgent\\",\\"ip\\":\\"$context.identity.sourceIp\\",\\"requestTime\\":\\"$context.requestTime\\",\\"requestTimeEpoch\\":\\"$context.requestTimeEpoch\\",\\"dataProcessed\\":\\"$context.dataProcessed\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"path\\":\\"$context.path\\",\\"routeKey\\":\\"$context.routeKey\\",\\"status\\":\\"$context.status\\",\\"protocol\\":\\"$context.protocol\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"domainName\\":\\"$context.domainName\\",\\"error\\":{\\"type\\":\\"$context.error.responseType\\",\\"gatewayError\\":\\"$context.error.message\\",\\"integrationError\\":\\"$context.integration.error\\",\\"authorizerError\\":\\"$context.authorizer.error\\"},\\"integration\\":{\\"latency\\":\\"$context.integration.latency\\",\\"requestId\\":\\"$context.integration.requestId\\",\\"responseStatus\\":\\"$context.integration.status\\"},\\"auth\\":{\\"iam\\":{\\"userArn\\":\\"$context.identity.userArn\\",\\"awsAccount\\":\\"$context.identity.accountId\\",\\"awsPrincipal\\":\\"$context.identity.caller\\",\\"awsPrincipalOrg\\":\\"$context.identity.principalOrgId\\"},\\"basic\\":{\\"username\\":\\"$context.authorizer.username\\"},\\"cognito\\":{\\"clientId\\":\\"$context.authorizer.clientId\\"}},\\"awsEndpointRequest\\":{\\"id\\":\\"$context.awsEndpointRequestId\\",\\"id2\\":\\"$context.awsEndpointRequestId2\\"},\\"message\\":\\"$context.identity.sourceIp - $context.httpMethod $context.domainName $context.path ($context.routeKey) - $context.status [$context.responseLatency ms]\\"}",
         },
         "ApiId": Object {
-          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
         },
         "AutoDeploy": true,
         "DefaultRouteSettings": Object {
@@ -1194,33 +1194,33 @@ Object {
         },
         "StageName": "$default",
         "Tags": Object {
-          "service": "my-test-eventbus-api",
+          "service": "my-test-eventbridge-api",
         },
       },
       "Type": "AWS::ApiGatewayV2::Stage",
     },
-    "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultStageStackTestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiundefined70F3D3CA": Object {
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStageStackTestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapiundefinedD37D84F1": Object {
       "DependsOn": Array [
-        "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
-        "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultStageEED9902C",
+        "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
+        "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStage58B6C162",
       ],
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
         },
         "DomainName": Object {
-          "Ref": "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+          "Ref": "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
         },
         "Stage": "$default",
       },
       "Type": "AWS::ApiGatewayV2::ApiMapping",
     },
-    "TestEventBusApiGatewayHttpApimytesteventbusapiStackTestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D1514A4PermissionEEF7A16D": Object {
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiStackTestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer870A40C8PermissionA9F7B186": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaBECC85A6",
+            "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE",
             "Arn",
           ],
         },
@@ -1239,11 +1239,11 @@ Object {
               },
               ":",
               Object {
-                "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+                "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
               },
               "/authorizers/",
               Object {
-                "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D9DBA27",
+                "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D",
               },
             ],
           ],
@@ -1251,23 +1251,23 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "TestEventBusApiGatewayRouteapieventbusadd74C3E729": Object {
+    "TestEventBridgeApiGatewayRouteapieventbridgeadd741B2F1D": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
         },
         "AuthorizationType": "CUSTOM",
         "AuthorizerId": Object {
-          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D9DBA27",
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D",
         },
-        "RouteKey": "ANY /api/eventbus/add",
+        "RouteKey": "ANY /api/eventbridge/add",
         "Target": Object {
           "Fn::Join": Array [
             "",
             Array [
               "integrations/",
               Object {
-                "Ref": "TestEventBusApiGatewayRouteapieventbusaddEventbusIntegration5A9D08F2",
+                "Ref": "TestEventBridgeApiGatewayRouteapieventbridgeaddEventbusIntegrationFC6B2233",
               },
             ],
           ],
@@ -1275,14 +1275,14 @@ Object {
       },
       "Type": "AWS::ApiGatewayV2::Route",
     },
-    "TestEventBusApiGatewayRouteapieventbusaddEventbusIntegration5A9D08F2": Object {
+    "TestEventBridgeApiGatewayRouteapieventbridgeaddEventbusIntegrationFC6B2233": Object {
       "Properties": Object {
         "ApiId": Object {
-          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
         },
         "CredentialsArn": Object {
           "Fn::GetAtt": Array [
-            "TestEventBusApiGatewayApiGwToEventBusServiceRole9DEF465C",
+            "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB",
             "Arn",
           ],
         },

--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -1,5 +1,524 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HTTP API Gateway creates API-GW HTTP API using EventBridge integration 1`] = `
+Object {
+  "Resources": Object {
+    "BasicAuthCredentialsSecretED3C53F8": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "Name": "/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials",
+        "SecretString": "{\\"username\\":\\"test-user\\",\\"password\\":\\"test-password\\"}",
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "EventBus7B8748AA": Object {
+      "Properties": Object {
+        "Name": "api-event-bus",
+      },
+      "Type": "AWS::Events::EventBus",
+    },
+    "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 180,
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbridge-api",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole96DE390C": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbridge-api",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicyA1E30C6D": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicyA1E30C6D",
+        "Roles": Array [
+          Object {
+            "Ref": "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole96DE390C",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Allows API-GW to put events to ",
+              Object {
+                "Fn::GetAtt": Array [
+                  "EventBus7B8748AA",
+                  "Arn",
+                ],
+              },
+            ],
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbridge-api",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDefaultPolicy405989BF": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "events:PutEvents",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "EventBus7B8748AA",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDefaultPolicy405989BF",
+        "Roles": Array [
+          Object {
+            "Ref": "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076": Object {
+      "Properties": Object {
+        "DomainName": "my-test-eventbridge-api.example.com",
+        "DomainNameConfigurations": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "TestEventBridgeApiGatewayCustomDomainHttpsCertificate0EDD7C1B",
+            },
+            "EndpointType": "REGIONAL",
+            "SecurityPolicy": "TLS_1_2",
+          },
+        ],
+        "Tags": Object {
+          "service": "my-test-eventbridge-api",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::DomainName",
+    },
+    "TestEventBridgeApiGatewayCustomDomainHttpsCertificate0EDD7C1B": Object {
+      "Properties": Object {
+        "DomainName": "my-test-eventbridge-api.example.com",
+        "DomainValidationOptions": Array [
+          Object {
+            "DomainName": "my-test-eventbridge-api.example.com",
+            "HostedZoneId": Object {
+              "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
+            },
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/TestEventBridgeApiGateway/CustomDomain/HttpsCertificate",
+          },
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbridge-api",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+    },
+    "TestEventBridgeApiGatewayCustomDomainRoute53ARecordApigwAlias02B67FD3": Object {
+      "Properties": Object {
+        "AliasTarget": Object {
+          "DNSName": Object {
+            "Fn::GetAtt": Array [
+              "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
+              "RegionalDomainName",
+            ],
+          },
+          "HostedZoneId": Object {
+            "Fn::GetAtt": Array [
+              "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
+              "RegionalHostedZoneId",
+            ],
+          },
+        },
+        "HostedZoneId": Object {
+          "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
+        },
+        "Name": "my-test-eventbridge-api.example.com.",
+        "Type": "A",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE": Object {
+      "DependsOn": Array [
+        "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8",
+        "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "503a7065146aeb795b5704997ee2be6df36849c367f08c6984aad6da2774ad69.zip",
+        },
+        "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
+        "Environment": Object {
+          "Variables": Object {
+            "CREDENTIALS_SECRET_NAME": "/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbridge-api",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbridge-api",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:eu-west-1:",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials-??????",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8",
+        "Roles": Array [
+          Object {
+            "Ref": "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC": Object {
+      "Properties": Object {
+        "Description": "An HTTP API for my-test-eventbridge-api.example.com.",
+        "DisableExecuteApiEndpoint": true,
+        "Name": "HttpApi-my-test-eventbridge-api",
+        "ProtocolType": "HTTP",
+        "Tags": Object {
+          "service": "my-test-eventbridge-api",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Api",
+    },
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
+        },
+        "AuthorizerPayloadFormatVersion": "2.0",
+        "AuthorizerResultTtlInSeconds": 1800,
+        "AuthorizerType": "REQUEST",
+        "AuthorizerUri": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE",
+                  "Arn",
+                ],
+              },
+              "/invocations",
+            ],
+          ],
+        },
+        "EnableSimpleResponses": true,
+        "IdentitySource": Array [
+          "$request.header.Authorization",
+        ],
+        "Name": "DefaultAuthorizer",
+      },
+      "Type": "AWS::ApiGatewayV2::Authorizer",
+    },
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStage58B6C162": Object {
+      "DependsOn": Array [
+        "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
+      ],
+      "Properties": Object {
+        "AccessLogSettings": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"userAgent\\":\\"$context.identity.userAgent\\",\\"ip\\":\\"$context.identity.sourceIp\\",\\"requestTime\\":\\"$context.requestTime\\",\\"requestTimeEpoch\\":\\"$context.requestTimeEpoch\\",\\"dataProcessed\\":\\"$context.dataProcessed\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"path\\":\\"$context.path\\",\\"routeKey\\":\\"$context.routeKey\\",\\"status\\":\\"$context.status\\",\\"protocol\\":\\"$context.protocol\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"domainName\\":\\"$context.domainName\\",\\"error\\":{\\"type\\":\\"$context.error.responseType\\",\\"gatewayError\\":\\"$context.error.message\\",\\"integrationError\\":\\"$context.integration.error\\",\\"authorizerError\\":\\"$context.authorizer.error\\"},\\"integration\\":{\\"latency\\":\\"$context.integration.latency\\",\\"requestId\\":\\"$context.integration.requestId\\",\\"responseStatus\\":\\"$context.integration.status\\"},\\"auth\\":{\\"iam\\":{\\"userArn\\":\\"$context.identity.userArn\\",\\"awsAccount\\":\\"$context.identity.accountId\\",\\"awsPrincipal\\":\\"$context.identity.caller\\",\\"awsPrincipalOrg\\":\\"$context.identity.principalOrgId\\"},\\"basic\\":{\\"username\\":\\"$context.authorizer.username\\"},\\"cognito\\":{\\"clientId\\":\\"$context.authorizer.clientId\\"}},\\"awsEndpointRequest\\":{\\"id\\":\\"$context.awsEndpointRequestId\\",\\"id2\\":\\"$context.awsEndpointRequestId2\\"},\\"message\\":\\"$context.identity.sourceIp - $context.httpMethod $context.domainName $context.path ($context.routeKey) - $context.status [$context.responseLatency ms]\\"}",
+        },
+        "ApiId": Object {
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
+        },
+        "AutoDeploy": true,
+        "DefaultRouteSettings": Object {
+          "DetailedMetricsEnabled": true,
+        },
+        "StageName": "$default",
+        "Tags": Object {
+          "service": "my-test-eventbridge-api",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Stage",
+    },
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStageStackTestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapiundefinedD37D84F1": Object {
+      "DependsOn": Array [
+        "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
+        "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStage58B6C162",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
+        },
+        "DomainName": Object {
+          "Ref": "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
+        },
+        "Stage": "$default",
+      },
+      "Type": "AWS::ApiGatewayV2::ApiMapping",
+    },
+    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiStackTestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer870A40C8PermissionA9F7B186": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
+              },
+              "/authorizers/",
+              Object {
+                "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "TestEventBridgeApiGatewayRouteapieventbridgeadd741B2F1D": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
+        },
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": Object {
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D",
+        },
+        "RouteKey": "ANY /api/eventbridge/add",
+        "Target": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "integrations/",
+              Object {
+                "Ref": "TestEventBridgeApiGatewayRouteapieventbridgeaddEventBridgeIntegration2175EBF8",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Route",
+    },
+    "TestEventBridgeApiGatewayRouteapieventbridgeaddEventBridgeIntegration2175EBF8": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
+        },
+        "CredentialsArn": Object {
+          "Fn::GetAtt": Array [
+            "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB",
+            "Arn",
+          ],
+        },
+        "IntegrationSubtype": "EventBridge-PutEvents",
+        "IntegrationType": "AWS_PROXY",
+        "PayloadFormatVersion": "1.0",
+        "RequestParameters": Object {
+          "Detail": "$request.body",
+          "DetailType": "liflig-test-http-api",
+          "EventBusName": Object {
+            "Ref": "EventBus7B8748AA",
+          },
+          "Source": "$context.apiId",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Integration",
+    },
+  },
+}
+`;
+
 exports[`HTTP API Gateway creates API-GW HTTP API using IAM auth and ALB integration 1`] = `
 Object {
   "Resources": Object {
@@ -777,525 +1296,6 @@ Object {
         },
         "TlsConfig": Object {
           "ServerNameToVerify": "my-test-service-behind-alb.example.com",
-        },
-      },
-      "Type": "AWS::ApiGatewayV2::Integration",
-    },
-  },
-}
-`;
-
-exports[`HTTP API Gateway creates API-GW HTTP API using basic auth and EventBridge integration 1`] = `
-Object {
-  "Resources": Object {
-    "BasicAuthCredentialsSecretED3C53F8": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "Name": "/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials",
-        "SecretString": "{\\"username\\":\\"test-user\\",\\"password\\":\\"test-password\\"}",
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "EventBus7B8748AA": Object {
-      "Properties": Object {
-        "Name": "api-event-bus",
-      },
-      "Type": "AWS::Events::EventBus",
-    },
-    "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "RetentionInDays": 180,
-        "Tags": Array [
-          Object {
-            "Key": "service",
-            "Value": "my-test-eventbridge-api",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole96DE390C": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "service",
-            "Value": "my-test-eventbridge-api",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicyA1E30C6D": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicyA1E30C6D",
-        "Roles": Array [
-          Object {
-            "Ref": "TestEventBridgeApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole96DE390C",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Description": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "Allows API-GW to put events to ",
-              Object {
-                "Fn::GetAtt": Array [
-                  "EventBus7B8748AA",
-                  "Arn",
-                ],
-              },
-            ],
-          ],
-        },
-        "Tags": Array [
-          Object {
-            "Key": "service",
-            "Value": "my-test-eventbridge-api",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDefaultPolicy405989BF": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "events:PutEvents",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "EventBus7B8748AA",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDefaultPolicy405989BF",
-        "Roles": Array [
-          Object {
-            "Ref": "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076": Object {
-      "Properties": Object {
-        "DomainName": "my-test-eventbridge-api.example.com",
-        "DomainNameConfigurations": Array [
-          Object {
-            "CertificateArn": Object {
-              "Ref": "TestEventBridgeApiGatewayCustomDomainHttpsCertificate0EDD7C1B",
-            },
-            "EndpointType": "REGIONAL",
-            "SecurityPolicy": "TLS_1_2",
-          },
-        ],
-        "Tags": Object {
-          "service": "my-test-eventbridge-api",
-        },
-      },
-      "Type": "AWS::ApiGatewayV2::DomainName",
-    },
-    "TestEventBridgeApiGatewayCustomDomainHttpsCertificate0EDD7C1B": Object {
-      "Properties": Object {
-        "DomainName": "my-test-eventbridge-api.example.com",
-        "DomainValidationOptions": Array [
-          Object {
-            "DomainName": "my-test-eventbridge-api.example.com",
-            "HostedZoneId": Object {
-              "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
-            },
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "Name",
-            "Value": "Stack/TestEventBridgeApiGateway/CustomDomain/HttpsCertificate",
-          },
-          Object {
-            "Key": "service",
-            "Value": "my-test-eventbridge-api",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-    },
-    "TestEventBridgeApiGatewayCustomDomainRoute53ARecordApigwAlias02B67FD3": Object {
-      "Properties": Object {
-        "AliasTarget": Object {
-          "DNSName": Object {
-            "Fn::GetAtt": Array [
-              "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
-              "RegionalDomainName",
-            ],
-          },
-          "HostedZoneId": Object {
-            "Fn::GetAtt": Array [
-              "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
-              "RegionalHostedZoneId",
-            ],
-          },
-        },
-        "HostedZoneId": Object {
-          "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
-        },
-        "Name": "my-test-eventbridge-api.example.com.",
-        "Type": "A",
-      },
-      "Type": "AWS::Route53::RecordSet",
-    },
-    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE": Object {
-      "DependsOn": Array [
-        "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8",
-        "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
-          },
-          "S3Key": "503a7065146aeb795b5704997ee2be6df36849c367f08c6984aad6da2774ad69.zip",
-        },
-        "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
-        "Environment": Object {
-          "Variables": Object {
-            "CREDENTIALS_SECRET_NAME": "/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials",
-          },
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-        "Tags": Array [
-          Object {
-            "Key": "service",
-            "Value": "my-test-eventbridge-api",
-          },
-        ],
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "service",
-            "Value": "my-test-eventbridge-api",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":secretsmanager:eu-west-1:",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials-??????",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy05EE7BE8",
-        "Roles": Array [
-          Object {
-            "Ref": "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole5F880716",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC": Object {
-      "Properties": Object {
-        "Description": "An HTTP API for my-test-eventbridge-api.example.com.",
-        "DisableExecuteApiEndpoint": true,
-        "Name": "HttpApi-my-test-eventbridge-api",
-        "ProtocolType": "HTTP",
-        "Tags": Object {
-          "service": "my-test-eventbridge-api",
-        },
-      },
-      "Type": "AWS::ApiGatewayV2::Api",
-    },
-    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
-        },
-        "AuthorizerPayloadFormatVersion": "2.0",
-        "AuthorizerResultTtlInSeconds": 1800,
-        "AuthorizerType": "REQUEST",
-        "AuthorizerUri": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE",
-                  "Arn",
-                ],
-              },
-              "/invocations",
-            ],
-          ],
-        },
-        "EnableSimpleResponses": true,
-        "IdentitySource": Array [
-          "$request.header.Authorization",
-        ],
-        "Name": "DefaultAuthorizer",
-      },
-      "Type": "AWS::ApiGatewayV2::Authorizer",
-    },
-    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStage58B6C162": Object {
-      "DependsOn": Array [
-        "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
-      ],
-      "Properties": Object {
-        "AccessLogSettings": Object {
-          "DestinationArn": Object {
-            "Fn::GetAtt": Array [
-              "TestEventBridgeApiGatewayAccessLogsAccessLogGroup0C1548DC",
-              "Arn",
-            ],
-          },
-          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"userAgent\\":\\"$context.identity.userAgent\\",\\"ip\\":\\"$context.identity.sourceIp\\",\\"requestTime\\":\\"$context.requestTime\\",\\"requestTimeEpoch\\":\\"$context.requestTimeEpoch\\",\\"dataProcessed\\":\\"$context.dataProcessed\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"path\\":\\"$context.path\\",\\"routeKey\\":\\"$context.routeKey\\",\\"status\\":\\"$context.status\\",\\"protocol\\":\\"$context.protocol\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"domainName\\":\\"$context.domainName\\",\\"error\\":{\\"type\\":\\"$context.error.responseType\\",\\"gatewayError\\":\\"$context.error.message\\",\\"integrationError\\":\\"$context.integration.error\\",\\"authorizerError\\":\\"$context.authorizer.error\\"},\\"integration\\":{\\"latency\\":\\"$context.integration.latency\\",\\"requestId\\":\\"$context.integration.requestId\\",\\"responseStatus\\":\\"$context.integration.status\\"},\\"auth\\":{\\"iam\\":{\\"userArn\\":\\"$context.identity.userArn\\",\\"awsAccount\\":\\"$context.identity.accountId\\",\\"awsPrincipal\\":\\"$context.identity.caller\\",\\"awsPrincipalOrg\\":\\"$context.identity.principalOrgId\\"},\\"basic\\":{\\"username\\":\\"$context.authorizer.username\\"},\\"cognito\\":{\\"clientId\\":\\"$context.authorizer.clientId\\"}},\\"awsEndpointRequest\\":{\\"id\\":\\"$context.awsEndpointRequestId\\",\\"id2\\":\\"$context.awsEndpointRequestId2\\"},\\"message\\":\\"$context.identity.sourceIp - $context.httpMethod $context.domainName $context.path ($context.routeKey) - $context.status [$context.responseLatency ms]\\"}",
-        },
-        "ApiId": Object {
-          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
-        },
-        "AutoDeploy": true,
-        "DefaultRouteSettings": Object {
-          "DetailedMetricsEnabled": true,
-        },
-        "StageName": "$default",
-        "Tags": Object {
-          "service": "my-test-eventbridge-api",
-        },
-      },
-      "Type": "AWS::ApiGatewayV2::Stage",
-    },
-    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStageStackTestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapiundefinedD37D84F1": Object {
-      "DependsOn": Array [
-        "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
-        "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultStage58B6C162",
-      ],
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
-        },
-        "DomainName": Object {
-          "Ref": "TestEventBridgeApiGatewayCustomDomainDomainNamemytesteventbridgeapi37BFE076",
-        },
-        "Stage": "$default",
-      },
-      "Type": "AWS::ApiGatewayV2::ApiMapping",
-    },
-    "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiStackTestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer870A40C8PermissionA9F7B186": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "TestEventBridgeApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaE17306FE",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:eu-west-1:",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
-              },
-              "/authorizers/",
-              Object {
-                "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D",
-              },
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "TestEventBridgeApiGatewayRouteapieventbridgeadd741B2F1D": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
-        },
-        "AuthorizationType": "CUSTOM",
-        "AuthorizerId": Object {
-          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiDefaultAuthorizer106D515D",
-        },
-        "RouteKey": "ANY /api/eventbridge/add",
-        "Target": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "integrations/",
-              Object {
-                "Ref": "TestEventBridgeApiGatewayRouteapieventbridgeaddEventbusIntegrationFC6B2233",
-              },
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::ApiGatewayV2::Route",
-    },
-    "TestEventBridgeApiGatewayRouteapieventbridgeaddEventbusIntegrationFC6B2233": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Ref": "TestEventBridgeApiGatewayHttpApimytesteventbridgeapiC8FFC5FC",
-        },
-        "CredentialsArn": Object {
-          "Fn::GetAtt": Array [
-            "TestEventBridgeApiGatewayApiGwToEventBusServiceRoleDD9C1BFB",
-            "Arn",
-          ],
-        },
-        "IntegrationSubtype": "EventBridge-PutEvents",
-        "IntegrationType": "AWS_PROXY",
-        "PayloadFormatVersion": "1.0",
-        "RequestParameters": Object {
-          "Detail": "$request.body",
-          "DetailType": "liflig-test-http-api",
-          "EventBusName": Object {
-            "Ref": "EventBus7B8748AA",
-          },
-          "Source": "$context.apiId",
         },
       },
       "Type": "AWS::ApiGatewayV2::Integration",

--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -785,6 +785,525 @@ Object {
 }
 `;
 
+exports[`HTTP API Gateway creates API-GW HTTP API using basic auth and EventBridge integration 1`] = `
+Object {
+  "Resources": Object {
+    "BasicAuthCredentialsSecretED3C53F8": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "Name": "/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials",
+        "SecretString": "{\\"username\\":\\"test-user\\",\\"password\\":\\"test-password\\"}",
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "EventBus7B8748AA": Object {
+      "Properties": Object {
+        "Name": "api-event-bus",
+      },
+      "Type": "AWS::Events::EventBus",
+    },
+    "TestEventBusApiGatewayAccessLogsAccessLogGroup98D2D6F0": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 180,
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbus-api",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole3DAA3EAC": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbus-api",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicy7F97823D": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "TestEventBusApiGatewayAccessLogsAccessLogGroup98D2D6F0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRoleDefaultPolicy7F97823D",
+        "Roles": Array [
+          Object {
+            "Ref": "TestEventBusApiGatewayAccessLogsApiGatewayPushToCloudwatchLogsRole3DAA3EAC",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestEventBusApiGatewayApiGwToEventBusServiceRole9DEF465C": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Allows API-GW to put events to ",
+              Object {
+                "Fn::GetAtt": Array [
+                  "EventBus7B8748AA",
+                  "Arn",
+                ],
+              },
+            ],
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbus-api",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestEventBusApiGatewayApiGwToEventBusServiceRoleDefaultPolicy70DAC53B": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "events:PutEvents",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "EventBus7B8748AA",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestEventBusApiGatewayApiGwToEventBusServiceRoleDefaultPolicy70DAC53B",
+        "Roles": Array [
+          Object {
+            "Ref": "TestEventBusApiGatewayApiGwToEventBusServiceRole9DEF465C",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0": Object {
+      "Properties": Object {
+        "DomainName": "my-test-eventbus-api.example.com",
+        "DomainNameConfigurations": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "TestEventBusApiGatewayCustomDomainHttpsCertificateBB4C14EF",
+            },
+            "EndpointType": "REGIONAL",
+            "SecurityPolicy": "TLS_1_2",
+          },
+        ],
+        "Tags": Object {
+          "service": "my-test-eventbus-api",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::DomainName",
+    },
+    "TestEventBusApiGatewayCustomDomainHttpsCertificateBB4C14EF": Object {
+      "Properties": Object {
+        "DomainName": "my-test-eventbus-api.example.com",
+        "DomainValidationOptions": Array [
+          Object {
+            "DomainName": "my-test-eventbus-api.example.com",
+            "HostedZoneId": Object {
+              "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
+            },
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/TestEventBusApiGateway/CustomDomain/HttpsCertificate",
+          },
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbus-api",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+    },
+    "TestEventBusApiGatewayCustomDomainRoute53ARecordApigwAlias834BD48C": Object {
+      "Properties": Object {
+        "AliasTarget": Object {
+          "DNSName": Object {
+            "Fn::GetAtt": Array [
+              "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+              "RegionalDomainName",
+            ],
+          },
+          "HostedZoneId": Object {
+            "Fn::GetAtt": Array [
+              "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+              "RegionalHostedZoneId",
+            ],
+          },
+        },
+        "HostedZoneId": Object {
+          "Fn::ImportValue": "SupportStack:ExportsOutputRefHostedZoneDB99F8662BBAE844",
+        },
+        "Name": "my-test-eventbus-api.example.com.",
+        "Type": "A",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
+    "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaBECC85A6": Object {
+      "DependsOn": Array [
+        "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy0C859BB9",
+        "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "503a7065146aeb795b5704997ee2be6df36849c367f08c6984aad6da2774ad69.zip",
+        },
+        "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
+        "Environment": Object {
+          "Variables": Object {
+            "CREDENTIALS_SECRET_NAME": "/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials",
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbus-api",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "service",
+            "Value": "my-test-eventbus-api",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy0C859BB9": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:eu-west-1:",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:/example/cdk/prod/myService/myservice.gateway.auth.basic.credentials-??????",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRoleDefaultPolicy0C859BB9",
+        "Roles": Array [
+          Object {
+            "Ref": "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaServiceRole42DB48B4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843": Object {
+      "Properties": Object {
+        "Description": "An HTTP API for my-test-eventbus-api.example.com.",
+        "DisableExecuteApiEndpoint": true,
+        "Name": "HttpApi-my-test-eventbus-api",
+        "ProtocolType": "HTTP",
+        "Tags": Object {
+          "service": "my-test-eventbus-api",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Api",
+    },
+    "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D9DBA27": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+        },
+        "AuthorizerPayloadFormatVersion": "2.0",
+        "AuthorizerResultTtlInSeconds": 1800,
+        "AuthorizerType": "REQUEST",
+        "AuthorizerUri": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaBECC85A6",
+                  "Arn",
+                ],
+              },
+              "/invocations",
+            ],
+          ],
+        },
+        "EnableSimpleResponses": true,
+        "IdentitySource": Array [
+          "$request.header.Authorization",
+        ],
+        "Name": "DefaultAuthorizer",
+      },
+      "Type": "AWS::ApiGatewayV2::Authorizer",
+    },
+    "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultStageEED9902C": Object {
+      "DependsOn": Array [
+        "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+      ],
+      "Properties": Object {
+        "AccessLogSettings": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "TestEventBusApiGatewayAccessLogsAccessLogGroup98D2D6F0",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"userAgent\\":\\"$context.identity.userAgent\\",\\"ip\\":\\"$context.identity.sourceIp\\",\\"requestTime\\":\\"$context.requestTime\\",\\"requestTimeEpoch\\":\\"$context.requestTimeEpoch\\",\\"dataProcessed\\":\\"$context.dataProcessed\\",\\"httpMethod\\":\\"$context.httpMethod\\",\\"path\\":\\"$context.path\\",\\"routeKey\\":\\"$context.routeKey\\",\\"status\\":\\"$context.status\\",\\"protocol\\":\\"$context.protocol\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"domainName\\":\\"$context.domainName\\",\\"error\\":{\\"type\\":\\"$context.error.responseType\\",\\"gatewayError\\":\\"$context.error.message\\",\\"integrationError\\":\\"$context.integration.error\\",\\"authorizerError\\":\\"$context.authorizer.error\\"},\\"integration\\":{\\"latency\\":\\"$context.integration.latency\\",\\"requestId\\":\\"$context.integration.requestId\\",\\"responseStatus\\":\\"$context.integration.status\\"},\\"auth\\":{\\"iam\\":{\\"userArn\\":\\"$context.identity.userArn\\",\\"awsAccount\\":\\"$context.identity.accountId\\",\\"awsPrincipal\\":\\"$context.identity.caller\\",\\"awsPrincipalOrg\\":\\"$context.identity.principalOrgId\\"},\\"basic\\":{\\"username\\":\\"$context.authorizer.username\\"},\\"cognito\\":{\\"clientId\\":\\"$context.authorizer.clientId\\"}},\\"awsEndpointRequest\\":{\\"id\\":\\"$context.awsEndpointRequestId\\",\\"id2\\":\\"$context.awsEndpointRequestId2\\"},\\"message\\":\\"$context.identity.sourceIp - $context.httpMethod $context.domainName $context.path ($context.routeKey) - $context.status [$context.responseLatency ms]\\"}",
+        },
+        "ApiId": Object {
+          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+        },
+        "AutoDeploy": true,
+        "DefaultRouteSettings": Object {
+          "DetailedMetricsEnabled": true,
+        },
+        "StageName": "$default",
+        "Tags": Object {
+          "service": "my-test-eventbus-api",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Stage",
+    },
+    "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultStageStackTestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiundefined70F3D3CA": Object {
+      "DependsOn": Array [
+        "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+        "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultStageEED9902C",
+      ],
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+        },
+        "DomainName": Object {
+          "Ref": "TestEventBusApiGatewayCustomDomainDomainNamemytesteventbusapiC1226DE0",
+        },
+        "Stage": "$default",
+      },
+      "Type": "AWS::ApiGatewayV2::ApiMapping",
+    },
+    "TestEventBusApiGatewayHttpApimytesteventbusapiStackTestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D1514A4PermissionEEF7A16D": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "TestEventBusApiGatewayDefaultAuthorizerLambdaBasicAuthLambdaBECC85A6",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+              },
+              "/authorizers/",
+              Object {
+                "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D9DBA27",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "TestEventBusApiGatewayRouteapieventbusadd74C3E729": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+        },
+        "AuthorizationType": "CUSTOM",
+        "AuthorizerId": Object {
+          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiDefaultAuthorizer1D9DBA27",
+        },
+        "RouteKey": "ANY /api/eventbus/add",
+        "Target": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "integrations/",
+              Object {
+                "Ref": "TestEventBusApiGatewayRouteapieventbusaddEventbusIntegration5A9D08F2",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Route",
+    },
+    "TestEventBusApiGatewayRouteapieventbusaddEventbusIntegration5A9D08F2": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "TestEventBusApiGatewayHttpApimytesteventbusapiC26A9843",
+        },
+        "CredentialsArn": Object {
+          "Fn::GetAtt": Array [
+            "TestEventBusApiGatewayApiGwToEventBusServiceRole9DEF465C",
+            "Arn",
+          ],
+        },
+        "IntegrationSubtype": "EventBridge-PutEvents",
+        "IntegrationType": "AWS_PROXY",
+        "PayloadFormatVersion": "1.0",
+        "RequestParameters": Object {
+          "Detail": "$request.body",
+          "DetailType": "liflig-test-http-api",
+          "EventBusName": Object {
+            "Ref": "EventBus7B8748AA",
+          },
+          "Source": "$context.apiId",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Integration",
+    },
+  },
+}
+`;
+
 exports[`HTTP API Gateway creates API-GW HTTP API using basic auth and SQS integration 1`] = `
 Object {
   "Resources": Object {
@@ -3264,7 +3783,7 @@ Object {
           "ZipFile": "
 export async function handler(event) {
   return { isAuthorized: false }
-}       
+}
 ",
         },
         "Handler": "handler",

--- a/src/api-gateway/__tests__/http-api-gateway.test.ts
+++ b/src/api-gateway/__tests__/http-api-gateway.test.ts
@@ -90,7 +90,7 @@ describe("HTTP API Gateway", () => {
     expect(stack).toMatchCdkSnapshot()
   })
 
-  test("creates API-GW HTTP API using basic auth and EventBridge integration", () => {
+  test("creates API-GW HTTP API using EventBridge integration", () => {
     const credentialsSecret = createBasicAuthCredentialsSecret()
 
     const eventBus = new EventBus(stack, "EventBus", {

--- a/src/api-gateway/__tests__/http-api-gateway.test.ts
+++ b/src/api-gateway/__tests__/http-api-gateway.test.ts
@@ -97,10 +97,10 @@ describe("HTTP API Gateway", () => {
       eventBusName: "api-event-bus",
     })
 
-    new ApiGateway(stack, "TestEventBusApiGateway", {
-      dns: { subdomain: "my-test-eventbus-api", hostedZone },
+    new ApiGateway(stack, "TestEventBridgeApiGateway", {
+      dns: { subdomain: "my-test-eventbridge-api", hostedZone },
       defaultIntegration: {
-        type: "EventBus",
+        type: "EventBridge",
         eventBus,
         detailType: "liflig-test-http-api",
       },
@@ -108,7 +108,7 @@ describe("HTTP API Gateway", () => {
         type: "BASIC_AUTH",
         credentialsSecretName: credentialsSecret.secretName,
       },
-      routes: [{ path: "/api/eventbus/add" }],
+      routes: [{ path: "/api/eventbridge/add" }],
       accessLogs,
     })
 

--- a/src/api-gateway/http-api-gateway.ts
+++ b/src/api-gateway/http-api-gateway.ts
@@ -162,7 +162,7 @@ export type IntegrationProps =
   /** Use this when connecting a route to send to an SQS queue. */
   | ({ type: "SQS" } & SqsIntegrationProps)
   /** Use this when connecting a route to send to an EventBus. */
-  | ({ type: "EventBus" } & EventBusIntegrationProps)
+  | ({ type: "EventBridge" } & EventBridgeIntegrationProps)
 
 /**
  * Props for the API-GW -> ALB (Application Load Balancer) integration.
@@ -281,7 +281,7 @@ export type SqsIntegrationProps = {
   }
 }
 
-export type EventBusIntegrationProps = {
+export type EventBridgeIntegrationProps = {
   eventBus: events.IEventBus
   detailType: string
 }
@@ -885,7 +885,7 @@ export class ApiGateway<
           payloadFormatVersion: apigw.PayloadFormatVersion.VERSION_1_0,
         })
       }
-      case "EventBus": {
+      case "EventBridge": {
         // API-GW does not have access to put events to event bus by default
         const role = new iam.Role(
           this,
@@ -898,7 +898,7 @@ export class ApiGateway<
         integration.eventBus.grantPutEventsTo(role)
 
         const parameterMapping = new apigw.ParameterMapping()
-          // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html#SQS-SendMessage
+          // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html#EventBridge-PutEvents
           .custom("EventBusName", integration.eventBus.eventBusName)
           .custom("Detail", "$request.body")
           // TODO: Figure out a better name


### PR DESCRIPTION
### Description

This pull request adds support for the `EventBridge-PutEvents 1.0` integration subtype in the `http-api-gateway` construct.

### Testing

Snapshot tests have been added, and a round of `cdk synth` and `cdk deploy` of an existing stack in the CN dev account have been run with
the "packed" version of this, to verify nothing "funny" happened.

### Audience

Team Cargonet intends to use this in a new integration they are currently building.

### Scope of impact

No consumers should be affected, as this is "expansive", and does not alter the existing integrations supported for the construct.
