### PR TITLE
feat: expose runtimePlatform on FargateService

### DIFF
--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HTTP API Gateway creates API-GW HTTP API using EventBridge integration with a default role 1`] = `
 Object {

--- a/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
+++ b/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`creates fargate service with parameters and listener rule 1`] = `
 Object {

--- a/src/ecs/fargate-service.ts
+++ b/src/ecs/fargate-service.ts
@@ -22,6 +22,10 @@ export interface FargateServiceProps {
    */
   cpu?: number
   /**
+   * @default undefined
+   */
+  runtimePlatform?: ecs.RuntimePlatform
+  /**
    * @default 512
    */
   memoryLimitMiB?: number
@@ -113,6 +117,7 @@ export class FargateService extends constructs.Construct {
       {
         cpu: props.cpu ?? 256,
         memoryLimitMiB: props.memoryLimitMiB ?? 512,
+        runtimePlatform: props.runtimePlatform,
       },
     )
 


### PR DESCRIPTION
### Description

_What are the changes?_
Allow specifying `operatingSystemFamily` on the `FargateService` construct

### Testing

_How will the changes be tested?_
Rolling out Arm-enabled Fargate services in some of the CargoNet apps.

### Audience

_Which teams currently needs these changes?_
CargoNet

### Scope of impact

_Which consumers will this change affect?_
This is a backwards compatible change, as the default of `undefined` is kept.
