### PR TITLE
new construct: WAF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ cdk.out/
 .idea
 docs/
 .DS_Store
+.claude/settings.local.json
+.serena/project.yml
+.serena/.gitignore
+.mcp.json
+AGENTS.md
+opencode.jsonc

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as loadBalancer from "./load-balancer"
 import * as platform from "./platform"
 import * as rds from "./rds"
 import * as ses from "./ses"
+import * as waf from "./waf"
 import * as webapp from "./webapp"
 
 // TODO: We want to switch exports so they every construct under
@@ -27,6 +28,7 @@ export {
   alarms,
   cdkPipelines,
   ses,
+  waf,
   webapp,
   configureParameters,
   ecs,

--- a/src/waf/__tests__/__snapshots__/waf.test.ts.snap
+++ b/src/waf/__tests__/__snapshots__/waf.test.ts.snap
@@ -1,0 +1,1998 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`create WAF and associate with ALB 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "LoadBalancer8E47CE52": Object {
+      "DependsOn": Array [
+        "LoadBalancerAccessLogsBucketPolicy6B02AF07",
+        "VPCPublicSubnet1DefaultRoute91CEF279",
+        "VPCPublicSubnet1RouteTableAssociation0B0896DC",
+        "VPCPublicSubnet2DefaultRouteB7481BBA",
+        "VPCPublicSubnet2RouteTableAssociation5A808732",
+      ],
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "false",
+          },
+          Object {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          Object {
+            "Key": "access_logs.s3.bucket",
+            "Value": Object {
+              "Ref": "LoadBalancerAccessLogsBucketD82011C7",
+            },
+          },
+          Object {
+            "Key": "access_logs.s3.prefix",
+            "Value": "",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerSecurityGroupC89CA14B",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Array [
+          Object {
+            "Ref": "VPCPublicSubnet1SubnetB4246D30",
+          },
+          Object {
+            "Ref": "VPCPublicSubnet2Subnet74179F39",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerAccessLogsBucketD82011C7": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LifecycleConfiguration": Object {
+          "Rules": Array [
+            Object {
+              "ExpirationInDays": 30,
+              "Status": "Enabled",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "LoadBalancerAccessLogsBucketPolicy6B02AF07": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "LoadBalancerAccessLogsBucketD82011C7",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::127311923021:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerAccessLogsBucketD82011C7",
+                        "Arn",
+                      ],
+                    },
+                    "/AWSLogs/",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "s3:x-amz-acl": "bucket-owner-full-control",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "delivery.logs.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "LoadBalancerAccessLogsBucketD82011C7",
+                        "Arn",
+                      ],
+                    },
+                    "/AWSLogs/",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetBucketAcl",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "delivery.logs.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "LoadBalancerAccessLogsBucketD82011C7",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "LoadBalancerDefaultTargetGroup162BFC2A": Object {
+      "Properties": Object {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "LoadBalancerHttpListener9DD37EAA": Object {
+      "Properties": Object {
+        "DefaultActions": Array [
+          Object {
+            "RedirectConfig": Object {
+              "Port": "443",
+              "Protocol": "HTTPS",
+              "StatusCode": "HTTP_301",
+            },
+            "Type": "redirect",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancer8E47CE52",
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerHttpsListener68D81C94": Object {
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/test",
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "LoadBalancerDefaultTargetGroup162BFC2A",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancer8E47CE52",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS-1-2-2017-01",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerSecurityGroupC89CA14B": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB StackLoadBalancerF0AF61AA",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "TestWafAssociationD84E01FA": Object {
+      "Properties": Object {
+        "ResourceArn": Object {
+          "Ref": "LoadBalancer8E47CE52",
+        },
+        "WebACLArn": Object {
+          "Fn::GetAtt": Array [
+            "TestWafWebACL78812FD0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::WAFv2::WebACLAssociation",
+    },
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "ALBWebACL",
+        "Rules": Array [
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesCommonRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 10,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesCommonRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "CoreRuleSet",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "ALBWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+    "VPCB9E5F0B4": Object {
+      "Properties": Object {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+    "VPCIGWB7E252D3": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::InternetGateway",
+    },
+    "VPCPrivateSubnet1DefaultRouteAE1D6490": Object {
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "VPCPublicSubnet1NATGatewayE0556630",
+        },
+        "RouteTableId": Object {
+          "Ref": "VPCPrivateSubnet1RouteTableBE8A6027",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "VPCPrivateSubnet1RouteTableAssociation347902D1": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "VPCPrivateSubnet1RouteTableBE8A6027",
+        },
+        "SubnetId": Object {
+          "Ref": "VPCPrivateSubnet1Subnet8BCA10E0",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "VPCPrivateSubnet1RouteTableBE8A6027": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PrivateSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "VPCPrivateSubnet1Subnet8BCA10E0": Object {
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            0,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.128.0/18",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PrivateSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "VPCPrivateSubnet2DefaultRouteF4F5CFD2": Object {
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "VPCPublicSubnet2NATGateway3C070193",
+        },
+        "RouteTableId": Object {
+          "Ref": "VPCPrivateSubnet2RouteTable0A19E10E",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "VPCPrivateSubnet2RouteTable0A19E10E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PrivateSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "VPCPrivateSubnet2RouteTableAssociation0C73D413": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "VPCPrivateSubnet2RouteTable0A19E10E",
+        },
+        "SubnetId": Object {
+          "Ref": "VPCPrivateSubnet2SubnetCFCDAA7A",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "VPCPrivateSubnet2SubnetCFCDAA7A": Object {
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            1,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.192.0/18",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PrivateSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "VPCPublicSubnet1DefaultRoute91CEF279": Object {
+      "DependsOn": Array [
+        "VPCVPCGW99B986DC",
+      ],
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "VPCIGWB7E252D3",
+        },
+        "RouteTableId": Object {
+          "Ref": "VPCPublicSubnet1RouteTableFEE4B781",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "VPCPublicSubnet1EIP6AD938E8": Object {
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet1",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "VPCPublicSubnet1NATGatewayE0556630": Object {
+      "DependsOn": Array [
+        "VPCPublicSubnet1DefaultRoute91CEF279",
+        "VPCPublicSubnet1RouteTableAssociation0B0896DC",
+      ],
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "VPCPublicSubnet1EIP6AD938E8",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "VPCPublicSubnet1SubnetB4246D30",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet1",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "VPCPublicSubnet1RouteTableAssociation0B0896DC": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "VPCPublicSubnet1RouteTableFEE4B781",
+        },
+        "SubnetId": Object {
+          "Ref": "VPCPublicSubnet1SubnetB4246D30",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "VPCPublicSubnet1RouteTableFEE4B781": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "VPCPublicSubnet1SubnetB4246D30": Object {
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            0,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.0.0/18",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "VPCPublicSubnet2DefaultRouteB7481BBA": Object {
+      "DependsOn": Array [
+        "VPCVPCGW99B986DC",
+      ],
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "VPCIGWB7E252D3",
+        },
+        "RouteTableId": Object {
+          "Ref": "VPCPublicSubnet2RouteTable6F1A15F1",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "VPCPublicSubnet2EIP4947BC00": Object {
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet2",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "VPCPublicSubnet2NATGateway3C070193": Object {
+      "DependsOn": Array [
+        "VPCPublicSubnet2DefaultRouteB7481BBA",
+        "VPCPublicSubnet2RouteTableAssociation5A808732",
+      ],
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "VPCPublicSubnet2EIP4947BC00",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "VPCPublicSubnet2Subnet74179F39",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet2",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "VPCPublicSubnet2RouteTable6F1A15F1": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "VPCPublicSubnet2RouteTableAssociation5A808732": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "VPCPublicSubnet2RouteTable6F1A15F1",
+        },
+        "SubnetId": Object {
+          "Ref": "VPCPublicSubnet2Subnet74179F39",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "VPCPublicSubnet2Subnet74179F39": Object {
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            1,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.64.0/18",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Stack/VPC/PublicSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "VPCVPCGW99B986DC": Object {
+      "Properties": Object {
+        "InternetGatewayId": Object {
+          "Ref": "VPCIGWB7E252D3",
+        },
+        "VpcId": Object {
+          "Ref": "VPCB9E5F0B4",
+        },
+      },
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF for CloudFront 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "CloudFrontWebACL",
+        "Rules": Array [
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesCommonRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 10,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesCommonRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "CoreRuleSet",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "CLOUDFRONT",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "CloudFrontWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with CloudWatch alarms 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafAllowedRequestsAlarm8E602A7C": Object {
+      "Properties": Object {
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": Array [
+          Object {
+            "Name": "Region",
+            "Value": Object {
+              "Ref": "AWS::Region",
+            },
+          },
+          Object {
+            "Name": "Rule",
+            "Value": "ALL",
+          },
+          Object {
+            "Name": "WebACL",
+            "Value": "AlarmedWebACL",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "AllowedRequests",
+        "Namespace": "AWS/WAFV2",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 10000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TestWafBlockedRequestsAlarm62DCF010": Object {
+      "Properties": Object {
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 2,
+        "Dimensions": Array [
+          Object {
+            "Name": "Region",
+            "Value": Object {
+              "Ref": "AWS::Region",
+            },
+          },
+          Object {
+            "Name": "Rule",
+            "Value": "ALL",
+          },
+          Object {
+            "Name": "WebACL",
+            "Value": "AlarmedWebACL",
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "BlockedRequests",
+        "Namespace": "AWS/WAFV2",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "AlarmedWebACL",
+        "Rules": Array [],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "AlarmedWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with both managed and custom rules 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "MixedRulesWebACL",
+        "Rules": Array [
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "BlockPath--api-internal",
+            "Priority": 1,
+            "Statement": Object {
+              "ByteMatchStatement": Object {
+                "FieldToMatch": Object {
+                  "UriPath": Object {},
+                },
+                "PositionalConstraint": "STARTS_WITH",
+                "SearchString": "/api/internal",
+                "TextTransformations": Array [
+                  Object {
+                    "Priority": 0,
+                    "Type": "NONE",
+                  },
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "BlockPath--api-internal",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Action": Object {
+              "Captcha": Object {},
+            },
+            "Name": "RateLimit-1000",
+            "Priority": 5,
+            "Statement": Object {
+              "RateBasedStatement": Object {
+                "AggregateKeyType": "FORWARDED_IP",
+                "Limit": 1000,
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "RateLimit-1000",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesCommonRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 100,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesCommonRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "CoreRuleSet",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesBotControlRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 110,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "ExcludedRules": Array [
+                  Object {
+                    "Name": "SignalNonBrowserUserAgent",
+                  },
+                ],
+                "Name": "AWSManagedRulesBotControlRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "BotControl",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "MixedRulesWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with custom response bodies 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "CustomResponseBodies": Object {
+          "BlockedResponse": Object {
+            "Content": "<html><body><h1>Access Denied</h1></body></html>",
+            "ContentType": "TEXT_HTML",
+          },
+          "RateLimitResponse": Object {
+            "Content": "{\\"error\\":\\"Too many requests\\"}",
+            "ContentType": "APPLICATION_JSON",
+          },
+        },
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "CustomResponseWebACL",
+        "Rules": Array [],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "CustomResponseWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with custom rules 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "AllowedIPsIPSetE3D7DE84": Object {
+      "Properties": Object {
+        "Addresses": Array [
+          "192.168.1.0/24",
+          "10.0.0.0/8",
+        ],
+        "Description": "Allowed IP addresses",
+        "IPAddressVersion": "IPV4",
+        "Scope": "REGIONAL",
+      },
+      "Type": "AWS::WAFv2::IPSet",
+    },
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Block": Object {},
+        },
+        "Name": "CustomRulesWebACL",
+        "Rules": Array [
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "BlockPath--admin",
+            "Priority": 1,
+            "Statement": Object {
+              "ByteMatchStatement": Object {
+                "FieldToMatch": Object {
+                  "UriPath": Object {},
+                },
+                "PositionalConstraint": "STARTS_WITH",
+                "SearchString": "/admin",
+                "TextTransformations": Array [
+                  Object {
+                    "Priority": 0,
+                    "Type": "NONE",
+                  },
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "BlockPath--admin",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "BlockPath--wp-admin",
+            "Priority": 2,
+            "Statement": Object {
+              "ByteMatchStatement": Object {
+                "FieldToMatch": Object {
+                  "UriPath": Object {},
+                },
+                "PositionalConstraint": "STARTS_WITH",
+                "SearchString": "/wp-admin",
+                "TextTransformations": Array [
+                  Object {
+                    "Priority": 0,
+                    "Type": "NONE",
+                  },
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "BlockPath--wp-admin",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Action": Object {
+              "Allow": Object {},
+            },
+            "Name": "AllowPath--public",
+            "Priority": 3,
+            "Statement": Object {
+              "ByteMatchStatement": Object {
+                "FieldToMatch": Object {
+                  "UriPath": Object {},
+                },
+                "PositionalConstraint": "STARTS_WITH",
+                "SearchString": "/public",
+                "TextTransformations": Array [
+                  Object {
+                    "Priority": 0,
+                    "Type": "NONE",
+                  },
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "AllowPath--public",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "RateLimit-2000",
+            "Priority": 5,
+            "Statement": Object {
+              "RateBasedStatement": Object {
+                "AggregateKeyType": "IP",
+                "Limit": 2000,
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "RateLimit-2000",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "GeoRestriction-CN-RU-KP",
+            "Priority": 10,
+            "Statement": Object {
+              "GeoMatchStatement": Object {
+                "CountryCodes": Array [
+                  "CN",
+                  "RU",
+                  "KP",
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "GeoRestriction",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Action": Object {
+              "Allow": Object {},
+            },
+            "Name": "IPAllowlist",
+            "Priority": 15,
+            "Statement": Object {
+              "IPSetReferenceStatement": Object {
+                "Arn": Object {
+                  "Fn::GetAtt": Array [
+                    "AllowedIPsIPSetE3D7DE84",
+                    "Arn",
+                  ],
+                },
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "IPAllowlist",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "CustomRulesWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with logging enabled 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafFirehoseRole5435522A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "firehose.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "TestWafFirehoseRoleDefaultPolicy9C61963B": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "TestWafLogBucket478886EF",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "TestWafLogBucket478886EF",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "TestWafFirehoseRoleDefaultPolicy9C61963B",
+        "Roles": Array [
+          Object {
+            "Ref": "TestWafFirehoseRole5435522A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestWafLogBucket478886EF": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LifecycleConfiguration": Object {
+          "Rules": Array [
+            Object {
+              "ExpirationInDays": 90,
+              "Status": "Enabled",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "TestWafLogDeliveryStream03772872": Object {
+      "Properties": Object {
+        "DeliveryStreamType": "DirectPut",
+        "S3DestinationConfiguration": Object {
+          "BucketARN": Object {
+            "Fn::GetAtt": Array [
+              "TestWafLogBucket478886EF",
+              "Arn",
+            ],
+          },
+          "CompressionFormat": "GZIP",
+          "ErrorOutputPrefix": "error/",
+          "Prefix": "waf-logs/",
+          "RoleARN": Object {
+            "Fn::GetAtt": Array [
+              "TestWafFirehoseRole5435522A",
+              "Arn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::KinesisFirehose::DeliveryStream",
+    },
+    "TestWafLogGroupDA38FA78": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "RetentionInDays": 14,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "TestWafLoggingConfiguration08359FA1": Object {
+      "Properties": Object {
+        "LogDestinationConfigs": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "TestWafLogDeliveryStream03772872",
+              "Arn",
+            ],
+          },
+        ],
+        "ResourceArn": Object {
+          "Fn::GetAtt": Array [
+            "TestWafWebACL78812FD0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::WAFv2::LoggingConfiguration",
+    },
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "LoggingEnabledWebACL",
+        "Rules": Array [],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "LoggingEnabledWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with managed rule groups 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Description": "Test Web ACL with managed rules",
+        "Name": "MyWebACL",
+        "Rules": Array [
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesCommonRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 10,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesCommonRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "CoreRuleSet",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesKnownBadInputsRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 20,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesKnownBadInputsRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "KnownBadInputs",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesSQLiRuleSet",
+            "OverrideAction": Object {
+              "None": Object {},
+            },
+            "Priority": 30,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesSQLiRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "SQLDatabase",
+              "SampledRequestsEnabled": true,
+            },
+          },
+          Object {
+            "Name": "ManagedRule-AWSManagedRulesBotControlRuleSet",
+            "OverrideAction": Object {
+              "Count": Object {},
+            },
+            "Priority": 40,
+            "Statement": Object {
+              "ManagedRuleGroupStatement": Object {
+                "Name": "AWSManagedRulesBotControlRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "ManagedRule-AWSManagedRulesBotControlRuleSet",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "MyWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with metrics disabled 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "NoMetricsWebACL",
+        "Rules": Array [],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": false,
+          "MetricName": "NoMetricsWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with regex pattern set 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "BadPatternsRegexPatternSetA88B0AA8": Object {
+      "Properties": Object {
+        "Description": "Patterns to block",
+        "RegularExpressionList": Array [
+          "[sS][qQ][lL].*[iI][nN][jJ][eE][cC][tT]",
+          "<script.*>",
+        ],
+        "Scope": "REGIONAL",
+      },
+      "Type": "AWS::WAFv2::RegexPatternSet",
+    },
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "RegexWebACL",
+        "Rules": Array [
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "RegexMatch",
+            "Priority": 1,
+            "Statement": Object {
+              "RegexPatternSetReferenceStatement": Object {
+                "Arn": Object {
+                  "Fn::GetAtt": Array [
+                    "BadPatternsRegexPatternSetA88B0AA8",
+                    "Arn",
+                  ],
+                },
+                "FieldToMatch": Object {
+                  "AllQueryArguments": Object {},
+                },
+                "TextTransformations": Array [
+                  Object {
+                    "Priority": 0,
+                    "Type": "NONE",
+                  },
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "RegexMatch",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "RegexWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create WAF with size constraint rule 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Name": "SizeConstraintWebACL",
+        "Rules": Array [
+          Object {
+            "Action": Object {
+              "Block": Object {},
+            },
+            "Name": "SizeConstraint-GT-8192",
+            "Priority": 1,
+            "Statement": Object {
+              "SizeConstraintStatement": Object {
+                "ComparisonOperator": "GT",
+                "FieldToMatch": Object {
+                  "Body": Object {},
+                },
+                "Size": 8192,
+                "TextTransformations": Array [
+                  Object {
+                    "Priority": 0,
+                    "Type": "NONE",
+                  },
+                ],
+              },
+            },
+            "VisibilityConfig": Object {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "SizeConstraint-GT-8192",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "SizeConstraintWebACL",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`create basic WAF with default settings 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "TestWafWebACL78812FD0": Object {
+      "Properties": Object {
+        "DefaultAction": Object {
+          "Allow": Object {},
+        },
+        "Rules": Array [],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": Object {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "WAF-c8f65d81261c4eb852749729cf4254bfa6199c8050",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/src/waf/__tests__/waf.test.ts
+++ b/src/waf/__tests__/waf.test.ts
@@ -1,0 +1,331 @@
+import "@aws-cdk/assert/jest"
+import * as cdk from "aws-cdk-lib"
+import * as certificatemanager from "aws-cdk-lib/aws-certificatemanager"
+import * as ec2 from "aws-cdk-lib/aws-ec2"
+import * as logs from "aws-cdk-lib/aws-logs"
+import "jest-cdk-snapshot"
+import { LoadBalancer } from "../../load-balancer"
+import {
+  AwsManagedRules,
+  ManagedRuleGroupBuilder,
+  RuleBuilder,
+  Waf,
+  WafIpSet,
+  WafRegexPatternSet,
+} from "../index"
+
+test("create basic WAF with default settings", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  new Waf(stack, "TestWaf")
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    Scope: "REGIONAL",
+    DefaultAction: {
+      Allow: {},
+    },
+    VisibilityConfig: {
+      SampledRequestsEnabled: true,
+      CloudWatchMetricsEnabled: true,
+    },
+  })
+})
+
+test("create WAF with managed rule groups", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  new Waf(stack, "TestWaf", {
+    name: "MyWebACL",
+    description: "Test Web ACL with managed rules",
+    managedRuleGroups: [
+      ManagedRuleGroupBuilder.coreRuleSet(10),
+      ManagedRuleGroupBuilder.knownBadInputs(20),
+      ManagedRuleGroupBuilder.sqlDatabase(30),
+      {
+        name: AwsManagedRules.BOT_CONTROL,
+        vendor: "AWS",
+        priority: 40,
+        overrideAction: "COUNT",
+      },
+    ],
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    Name: "MyWebACL",
+    Description: "Test Web ACL with managed rules",
+  })
+})
+
+test("create WAF with custom rules", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  const ipSet = new WafIpSet(stack, "AllowedIPs", {
+    addresses: ["192.168.1.0/24", "10.0.0.0/8"],
+    description: "Allowed IP addresses",
+  })
+
+  new Waf(stack, "TestWaf", {
+    name: "CustomRulesWebACL",
+    customRules: [
+      RuleBuilder.blockPath("/admin", 1),
+      RuleBuilder.blockPath("/wp-admin", 2),
+      RuleBuilder.allowPath("/public", 3),
+      RuleBuilder.rateLimit(2000, 5, { aggregateKeyType: "IP" }),
+      RuleBuilder.geoBlock(["CN", "RU", "KP"], 10),
+      RuleBuilder.ipAllowlist(ipSet.arn, 15),
+    ],
+    defaultAction: "BLOCK",
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    Name: "CustomRulesWebACL",
+    DefaultAction: {
+      Block: {},
+    },
+  })
+})
+
+test("create WAF with both managed and custom rules", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  new Waf(stack, "TestWaf", {
+    name: "MixedRulesWebACL",
+    managedRuleGroups: [
+      ManagedRuleGroupBuilder.coreRuleSet(100),
+      ManagedRuleGroupBuilder.botControl(110, {
+        excludedRules: ["SignalNonBrowserUserAgent"],
+      }),
+    ],
+    customRules: [
+      RuleBuilder.blockPath("/api/internal", 1),
+      RuleBuilder.rateLimit(1000, 5, {
+        aggregateKeyType: "FORWARDED_IP",
+        action: "CAPTCHA",
+      }),
+    ],
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+})
+
+test("create WAF with logging enabled", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  new Waf(stack, "TestWaf", {
+    name: "LoggingEnabledWebACL",
+    enableLogging: true,
+    logRetention: logs.RetentionDays.TWO_WEEKS,
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::S3::Bucket", {
+    BucketEncryption: {
+      ServerSideEncryptionConfiguration: [
+        {
+          ServerSideEncryptionByDefault: {
+            SSEAlgorithm: "AES256",
+          },
+        },
+      ],
+    },
+  })
+  expect(template).toHaveResourceLike("AWS::KinesisFirehose::DeliveryStream", {
+    DeliveryStreamType: "DirectPut",
+  })
+  expect(template).toHaveResourceLike("AWS::WAFv2::LoggingConfiguration", {})
+})
+
+test("create WAF for CloudFront", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack", {
+    env: { region: "us-east-1" }, // CloudFront WAFs must be in us-east-1
+  })
+
+  new Waf(stack, "TestWaf", {
+    name: "CloudFrontWebACL",
+    scope: "CLOUDFRONT",
+    managedRuleGroups: [ManagedRuleGroupBuilder.coreRuleSet(10)],
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    Scope: "CLOUDFRONT",
+  })
+})
+
+test("create WAF and associate with ALB", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack", {
+    env: { region: "us-east-1" },
+  })
+
+  const vpc = new ec2.Vpc(stack, "VPC")
+  const certificate = certificatemanager.Certificate.fromCertificateArn(
+    stack,
+    "Certificate",
+    "arn:aws:acm:us-east-1:123456789012:certificate/test",
+  )
+
+  const loadBalancer = new LoadBalancer(stack, "LoadBalancer", {
+    certificates: [certificate],
+    vpc,
+  })
+
+  const waf = new Waf(stack, "TestWaf", {
+    name: "ALBWebACL",
+    managedRuleGroups: [ManagedRuleGroupBuilder.coreRuleSet(10)],
+  })
+
+  waf.associateWithResource(loadBalancer.loadBalancer.loadBalancerArn)
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACLAssociation", {})
+})
+
+test("create WAF with custom response bodies", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  new Waf(stack, "TestWaf", {
+    name: "CustomResponseWebACL",
+    customResponseBodies: {
+      BlockedResponse: {
+        content: "<html><body><h1>Access Denied</h1></body></html>",
+        contentType: "TEXT_HTML",
+      },
+      RateLimitResponse: {
+        content: JSON.stringify({ error: "Too many requests" }),
+        contentType: "APPLICATION_JSON",
+      },
+    },
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    CustomResponseBodies: {
+      BlockedResponse: {
+        Content: "<html><body><h1>Access Denied</h1></body></html>",
+        ContentType: "TEXT_HTML",
+      },
+      RateLimitResponse: {
+        Content: '{"error":"Too many requests"}',
+        ContentType: "APPLICATION_JSON",
+      },
+    },
+  })
+})
+
+test("create WAF with regex pattern set", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  const regexSet = new WafRegexPatternSet(stack, "BadPatterns", {
+    patterns: ["[sS][qQ][lL].*[iI][nN][jJ][eE][cC][tT]", "<script.*>"],
+    description: "Patterns to block",
+  })
+
+  new Waf(stack, "TestWaf", {
+    name: "RegexWebACL",
+    customRules: [
+      RuleBuilder.regexMatch(
+        regexSet.arn,
+        { allQueryArguments: {} },
+        1,
+        "BLOCK",
+      ),
+    ],
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::RegexPatternSet", {
+    Scope: "REGIONAL",
+  })
+})
+
+test("create WAF with size constraint rule", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  new Waf(stack, "TestWaf", {
+    name: "SizeConstraintWebACL",
+    customRules: [
+      RuleBuilder.sizeConstraint(8192, "GT", { body: {} }, 1, "BLOCK"),
+    ],
+  })
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    Name: "SizeConstraintWebACL",
+  })
+})
+
+test("create WAF with CloudWatch alarms", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  const waf = new Waf(stack, "TestWaf", {
+    name: "AlarmedWebACL",
+  })
+
+  waf.addBlockedRequestsAlarm(100, 2, 2)
+  waf.addAllowedRequestsAlarm(10000, 1, 1)
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::CloudWatch::Alarm", {
+    MetricName: "BlockedRequests",
+    Threshold: 100,
+    EvaluationPeriods: 2,
+    DatapointsToAlarm: 2,
+  })
+  expect(template).toHaveResourceLike("AWS::CloudWatch::Alarm", {
+    MetricName: "AllowedRequests",
+    Threshold: 10000,
+  })
+})
+
+test("create WAF with metrics disabled", () => {
+  const app = new cdk.App()
+  const stack = new cdk.Stack(app, "Stack")
+
+  const waf = new Waf(stack, "TestWaf", {
+    name: "NoMetricsWebACL",
+    enableMetrics: false,
+  })
+
+  // Metric property should be undefined
+  expect(waf.metric).toBeUndefined()
+
+  // Should throw error when trying to create allowed requests alarm
+  expect(() => {
+    waf.addAllowedRequestsAlarm(10000)
+  }).toThrow("Cannot create allowed requests alarm when metrics are disabled")
+
+  const template = app.synth().getStackByName(stack.stackName).template
+  expect(template).toMatchSnapshot()
+  expect(template).toHaveResourceLike("AWS::WAFv2::WebACL", {
+    Name: "NoMetricsWebACL",
+    VisibilityConfig: {
+      CloudWatchMetricsEnabled: false,
+      SampledRequestsEnabled: true,
+    },
+  })
+})

--- a/src/waf/custom-rules.ts
+++ b/src/waf/custom-rules.ts
@@ -1,0 +1,471 @@
+import * as wafv2 from "aws-cdk-lib/aws-wafv2"
+import * as constructs from "constructs"
+
+export interface CustomRule {
+  /**
+   * Name of the rule
+   */
+  name: string
+
+  /**
+   * Priority of the rule in the Web ACL
+   */
+  priority: number
+
+  /**
+   * Action to take when the rule matches
+   */
+  action: RuleAction
+
+  /**
+   * Statement that defines the rule
+   */
+  statement: wafv2.CfnWebACL.StatementProperty
+
+  /**
+   * Visibility configuration for CloudWatch metrics
+   */
+  visibilityConfig?: VisibilityConfig
+
+  /**
+   * Labels to add to requests that match the rule
+   */
+  ruleLabels?: string[]
+
+  /**
+   * CAPTCHA configuration
+   */
+  captchaConfig?: wafv2.CfnWebACL.CaptchaConfigProperty
+
+  /**
+   * Challenge configuration
+   */
+  challengeConfig?: wafv2.CfnWebACL.ChallengeConfigProperty
+}
+
+export type RuleAction = "ALLOW" | "BLOCK" | "COUNT" | "CAPTCHA" | "CHALLENGE"
+
+export interface VisibilityConfig {
+  sampledRequestsEnabled: boolean
+  cloudWatchMetricsEnabled: boolean
+  metricName: string
+}
+
+/**
+ * Builder class for creating custom WAF rules
+ */
+export class RuleBuilder {
+  /**
+   * Create a rule to block specific paths
+   */
+  static blockPath(path: string, priority: number): CustomRule {
+    const safeName = `BlockPath-${path.replace(/[^a-zA-Z0-9]/g, "-")}`
+    return {
+      name: safeName,
+      priority,
+      action: "BLOCK",
+      statement: {
+        byteMatchStatement: {
+          searchString: path,
+          fieldToMatch: {
+            uriPath: {},
+          },
+          textTransformations: [
+            {
+              priority: 0,
+              type: "NONE",
+            },
+          ],
+          positionalConstraint: "STARTS_WITH",
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: safeName,
+      },
+    }
+  }
+
+  /**
+   * Create a rule to allow specific paths
+   */
+  static allowPath(path: string, priority: number): CustomRule {
+    const safeName = `AllowPath-${path.replace(/[^a-zA-Z0-9]/g, "-")}`
+    return {
+      name: safeName,
+      priority,
+      action: "ALLOW",
+      statement: {
+        byteMatchStatement: {
+          searchString: path,
+          fieldToMatch: {
+            uriPath: {},
+          },
+          textTransformations: [
+            {
+              priority: 0,
+              type: "NONE",
+            },
+          ],
+          positionalConstraint: "STARTS_WITH",
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: safeName,
+      },
+    }
+  }
+
+  /**
+   * Create a rate-based rule to limit requests
+   */
+  static rateLimit(
+    limit: number,
+    priority: number,
+    options?: {
+      aggregateKeyType?: "IP" | "FORWARDED_IP" | "CUSTOM_KEYS"
+      scopeDownStatement?: wafv2.CfnWebACL.StatementProperty
+      customKeys?: wafv2.CfnWebACL.RateBasedStatementCustomKeyProperty[]
+      action?: RuleAction
+    },
+  ): CustomRule {
+    return {
+      name: `RateLimit-${limit}`,
+      priority,
+      action: options?.action || "BLOCK",
+      statement: {
+        rateBasedStatement: {
+          limit,
+          aggregateKeyType: options?.aggregateKeyType || "IP",
+          scopeDownStatement: options?.scopeDownStatement,
+          customKeys: options?.customKeys,
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: `RateLimit-${limit}`,
+      },
+    }
+  }
+
+  /**
+   * Create a geo-blocking rule
+   */
+  static geoBlock(
+    countryCodes: string[],
+    priority: number,
+    action: RuleAction = "BLOCK",
+  ): CustomRule {
+    return {
+      name: `GeoRestriction-${countryCodes.join("-")}`,
+      priority,
+      action,
+      statement: {
+        geoMatchStatement: {
+          countryCodes,
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "GeoRestriction",
+      },
+    }
+  }
+
+  /**
+   * Create an IP allowlist rule
+   */
+  static ipAllowlist(ipSetArn: string, priority: number): CustomRule {
+    return {
+      name: "IPAllowlist",
+      priority,
+      action: "ALLOW",
+      statement: {
+        ipSetReferenceStatement: {
+          arn: ipSetArn,
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "IPAllowlist",
+      },
+    }
+  }
+
+  /**
+   * Create an IP blocklist rule
+   */
+  static ipBlocklist(ipSetArn: string, priority: number): CustomRule {
+    return {
+      name: "IPBlocklist",
+      priority,
+      action: "BLOCK",
+      statement: {
+        ipSetReferenceStatement: {
+          arn: ipSetArn,
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "IPBlocklist",
+      },
+    }
+  }
+
+  /**
+   * Create a rule based on regex pattern matching
+   */
+  static regexMatch(
+    regexPatternSetArn: string,
+    fieldToMatch: wafv2.CfnWebACL.FieldToMatchProperty,
+    priority: number,
+    action: RuleAction = "BLOCK",
+  ): CustomRule {
+    return {
+      name: "RegexMatch",
+      priority,
+      action,
+      statement: {
+        regexPatternSetReferenceStatement: {
+          arn: regexPatternSetArn,
+          fieldToMatch,
+          textTransformations: [
+            {
+              priority: 0,
+              type: "NONE",
+            },
+          ],
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "RegexMatch",
+      },
+    }
+  }
+
+  /**
+   * Create a rule that requires CAPTCHA validation
+   */
+  static captcha(
+    statement: wafv2.CfnWebACL.StatementProperty,
+    priority: number,
+    name: string,
+  ): CustomRule {
+    return {
+      name: `CAPTCHA-${name}`,
+      priority,
+      action: "CAPTCHA",
+      statement,
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: `CAPTCHA-${name}`,
+      },
+    }
+  }
+
+  /**
+   * Create a rule based on request size
+   */
+  static sizeConstraint(
+    size: number,
+    comparisonOperator: "EQ" | "NE" | "LE" | "LT" | "GE" | "GT",
+    fieldToMatch: wafv2.CfnWebACL.FieldToMatchProperty,
+    priority: number,
+    action: RuleAction = "BLOCK",
+  ): CustomRule {
+    return {
+      name: `SizeConstraint-${comparisonOperator}-${size}`,
+      priority,
+      action,
+      statement: {
+        sizeConstraintStatement: {
+          fieldToMatch,
+          comparisonOperator,
+          size,
+          textTransformations: [
+            {
+              priority: 0,
+              type: "NONE",
+            },
+          ],
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: `SizeConstraint-${comparisonOperator}-${size}`,
+      },
+    }
+  }
+
+  /**
+   * Create a rule with multiple conditions (AND logic)
+   */
+  static andRule(
+    statements: wafv2.CfnWebACL.StatementProperty[],
+    priority: number,
+    action: RuleAction,
+    name: string,
+  ): CustomRule {
+    return {
+      name,
+      priority,
+      action,
+      statement: {
+        andStatement: {
+          statements,
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: name,
+      },
+    }
+  }
+
+  /**
+   * Create a rule with multiple conditions (OR logic)
+   */
+  static orRule(
+    statements: wafv2.CfnWebACL.StatementProperty[],
+    priority: number,
+    action: RuleAction,
+    name: string,
+  ): CustomRule {
+    return {
+      name,
+      priority,
+      action,
+      statement: {
+        orStatement: {
+          statements,
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: name,
+      },
+    }
+  }
+
+  /**
+   * Create a custom rule from a raw statement
+   */
+  static custom(
+    statement: wafv2.CfnWebACL.StatementProperty,
+    priority: number,
+    action: RuleAction,
+    name: string,
+    visibilityConfig?: VisibilityConfig,
+  ): CustomRule {
+    return {
+      name,
+      priority,
+      action,
+      statement,
+      visibilityConfig: visibilityConfig || {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: name,
+      },
+    }
+  }
+}
+
+/**
+ * Construct for creating WAF IP Sets
+ */
+export class WafIpSet extends constructs.Construct {
+  public readonly ipSet: wafv2.CfnIPSet
+  public readonly arn: string
+
+  constructor(
+    scope: constructs.Construct,
+    id: string,
+    props: {
+      /**
+       * IP addresses or CIDR blocks
+       */
+      addresses: string[]
+      /**
+       * IP version
+       * @default IPV4
+       */
+      ipVersion?: "IPV4" | "IPV6"
+      /**
+       * Scope of the IP set
+       * @default REGIONAL
+       */
+      scope?: "REGIONAL" | "CLOUDFRONT"
+      /**
+       * Description of the IP set
+       */
+      description?: string
+    },
+  ) {
+    super(scope, id)
+
+    this.ipSet = new wafv2.CfnIPSet(this, "IPSet", {
+      addresses: props.addresses,
+      ipAddressVersion: props.ipVersion || "IPV4",
+      scope: props.scope || "REGIONAL",
+      description: props.description,
+    })
+
+    this.arn = this.ipSet.attrArn
+  }
+}
+
+/**
+ * Construct for creating WAF Regex Pattern Sets
+ */
+export class WafRegexPatternSet extends constructs.Construct {
+  public readonly regexPatternSet: wafv2.CfnRegexPatternSet
+  public readonly arn: string
+
+  constructor(
+    scope: constructs.Construct,
+    id: string,
+    props: {
+      /**
+       * Regular expression patterns
+       */
+      patterns: string[]
+      /**
+       * Scope of the regex pattern set
+       * @default REGIONAL
+       */
+      scope?: "REGIONAL" | "CLOUDFRONT"
+      /**
+       * Description of the regex pattern set
+       */
+      description?: string
+    },
+  ) {
+    super(scope, id)
+
+    this.regexPatternSet = new wafv2.CfnRegexPatternSet(
+      this,
+      "RegexPatternSet",
+      {
+        regularExpressionList: props.patterns,
+        scope: props.scope || "REGIONAL",
+        description: props.description,
+      },
+    )
+
+    this.arn = this.regexPatternSet.attrArn
+  }
+}

--- a/src/waf/index.ts
+++ b/src/waf/index.ts
@@ -1,0 +1,14 @@
+export {
+  type CustomRule,
+  type RuleAction,
+  RuleBuilder,
+  type VisibilityConfig,
+  WafIpSet,
+  WafRegexPatternSet,
+} from "./custom-rules"
+export {
+  AwsManagedRules,
+  type ManagedRuleGroup,
+  ManagedRuleGroupBuilder,
+} from "./managed-rule-groups"
+export { Waf, type WafProps } from "./waf"

--- a/src/waf/managed-rule-groups.ts
+++ b/src/waf/managed-rule-groups.ts
@@ -1,0 +1,265 @@
+import type * as wafv2 from "aws-cdk-lib/aws-wafv2"
+
+/**
+ * AWS Managed Rules for AWS WAF
+ * @see https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html
+ */
+export enum AwsManagedRules {
+  // Baseline rule groups
+  CORE_RULE_SET = "AWSManagedRulesCommonRuleSet",
+  ADMIN_PROTECTION = "AWSManagedRulesAdminProtectionRuleSet",
+  KNOWN_BAD_INPUTS = "AWSManagedRulesKnownBadInputsRuleSet",
+
+  // Use-case specific rule groups
+  SQL_DATABASE = "AWSManagedRulesSQLiRuleSet",
+  LINUX_OS = "AWSManagedRulesLinuxRuleSet",
+  POSIX_OS = "AWSManagedRulesUnixRuleSet",
+  WINDOWS_OS = "AWSManagedRulesWindowsRuleSet",
+  PHP_APPLICATION = "AWSManagedRulesPHPRuleSet",
+  WORDPRESS_APPLICATION = "AWSManagedRulesWordPressRuleSet",
+
+  // IP reputation rule groups
+  AMAZON_IP_REPUTATION = "AWSManagedRulesAmazonIpReputationList",
+  ANONYMOUS_IP = "AWSManagedRulesAnonymousIPList",
+
+  // Bot Control
+  BOT_CONTROL = "AWSManagedRulesBotControlRuleSet",
+
+  // DDoS prevention
+  DDOS_PREVENTION = "AWSManagedRulesDDoSRuleSet",
+
+  // Fraud Control
+  ACCOUNT_TAKEOVER_PREVENTION = "AWSManagedRulesATPRuleSet",
+  ACCOUNT_CREATION_FRAUD_PREVENTION = "AWSManagedRulesACFPRuleSet",
+}
+
+export interface ManagedRuleGroup {
+  /**
+   * Name of the managed rule group
+   */
+  name: AwsManagedRules | string
+
+  /**
+   * Vendor of the managed rule group
+   * @default "AWS"
+   */
+  vendor?: string
+
+  /**
+   * Priority of the rule group in the Web ACL
+   */
+  priority: number
+
+  /**
+   * Override action for the rule group
+   * @default "NONE"
+   */
+  overrideAction?: "NONE" | "COUNT"
+
+  /**
+   * Rules to exclude from the rule group
+   */
+  excludedRules?: string[]
+
+  /**
+   * Scope down statement to narrow the requests that the rule group inspects
+   */
+  scopeDownStatement?: wafv2.CfnWebACL.StatementProperty
+
+  /**
+   * Visibility configuration for CloudWatch metrics
+   */
+  visibilityConfig?: {
+    sampledRequestsEnabled: boolean
+    cloudWatchMetricsEnabled: boolean
+    metricName: string
+  }
+
+  /**
+   * Version of the managed rule group
+   * @default Latest version
+   */
+  version?: string
+}
+
+/**
+ * Builder class for creating managed rule group configurations
+ */
+export class ManagedRuleGroupBuilder {
+  /**
+   * Create the Core Rule Set managed rule group
+   * Provides protection against OWASP Top 10 and common vulnerabilities
+   */
+  static coreRuleSet(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.CORE_RULE_SET,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "CoreRuleSet",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create the Known Bad Inputs managed rule group
+   * Blocks request patterns known to be invalid or associated with exploitation
+   */
+  static knownBadInputs(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.KNOWN_BAD_INPUTS,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "KnownBadInputs",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create the SQL Database managed rule group
+   * Provides protection against SQL injection attacks
+   */
+  static sqlDatabase(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.SQL_DATABASE,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "SQLDatabase",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create the Admin Protection managed rule group
+   * Blocks external access to exposed admin pages
+   */
+  static adminProtection(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.ADMIN_PROTECTION,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "AdminProtection",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create the Bot Control managed rule group
+   * Manages bot traffic to your application
+   */
+  static botControl(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.BOT_CONTROL,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "BotControl",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create the Amazon IP Reputation List managed rule group
+   * Blocks requests from IP addresses with poor reputation
+   */
+  static amazonIpReputation(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.AMAZON_IP_REPUTATION,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "AmazonIpReputation",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create the Anonymous IP List managed rule group
+   * Blocks requests from services that hide viewer identity
+   */
+  static anonymousIp(
+    priority: number,
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name: AwsManagedRules.ANONYMOUS_IP,
+      vendor: "AWS",
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "AnonymousIp",
+      },
+      ...options,
+    }
+  }
+
+  /**
+   * Create a custom managed rule group configuration
+   */
+  static custom(
+    name: string,
+    priority: number,
+    vendor = "AWS",
+    options?: Partial<ManagedRuleGroup>,
+  ): ManagedRuleGroup {
+    return {
+      name,
+      vendor,
+      priority,
+      overrideAction: "NONE",
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: name.replace(/[^a-zA-Z0-9]/g, ""),
+      },
+      ...options,
+    }
+  }
+}

--- a/src/waf/waf.ts
+++ b/src/waf/waf.ts
@@ -1,0 +1,349 @@
+import * as cdk from "aws-cdk-lib"
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch"
+import * as iam from "aws-cdk-lib/aws-iam"
+import * as kinesisfirehose from "aws-cdk-lib/aws-kinesisfirehose"
+import * as logs from "aws-cdk-lib/aws-logs"
+import * as s3 from "aws-cdk-lib/aws-s3"
+import * as wafv2 from "aws-cdk-lib/aws-wafv2"
+import * as constructs from "constructs"
+import type { CustomRule } from "./custom-rules"
+import type { ManagedRuleGroup } from "./managed-rule-groups"
+
+export interface WafProps {
+  /**
+   * Name of the Web ACL
+   */
+  name?: string
+
+  /**
+   * Description of the Web ACL
+   */
+  description?: string
+
+  /**
+   * Scope of the WAF
+   * CLOUDFRONT for CloudFront distributions (must be in us-east-1)
+   * REGIONAL for ALB, API Gateway, AppSync, Cognito User Pool, App Runner, Verified Access
+   * @default REGIONAL
+   */
+  scope?: "REGIONAL" | "CLOUDFRONT"
+
+  /**
+   * Managed rule groups to include
+   */
+  managedRuleGroups?: ManagedRuleGroup[]
+
+  /**
+   * Custom rules
+   */
+  customRules?: CustomRule[]
+
+  /**
+   * Default action for requests that don't match any rules
+   * @default ALLOW
+   */
+  defaultAction?: "ALLOW" | "BLOCK"
+
+  /**
+   * Enable CloudWatch metrics
+   * When disabled, the metric property will not be created
+   * @default true
+   */
+  enableMetrics?: boolean
+
+  /**
+   * Enable logging
+   * @default false
+   */
+  enableLogging?: boolean
+
+  /**
+   * Log retention in days (only used if enableLogging is true)
+   * @default 7
+   */
+  logRetention?: logs.RetentionDays
+
+  /**
+   * Enable sampled requests
+   * @default true
+   */
+  enableSampledRequests?: boolean
+
+  /**
+   * Custom response bodies
+   */
+  customResponseBodies?: {
+    [key: string]: {
+      content: string
+      contentType: "TEXT_PLAIN" | "TEXT_HTML" | "APPLICATION_JSON"
+    }
+  }
+
+  /**
+   * Token domains for CAPTCHA and Challenge
+   */
+  tokenDomains?: string[]
+
+  /**
+   * Override CfnWebACL properties
+   */
+  overrideWebAclProps?: Partial<wafv2.CfnWebACLProps>
+}
+
+export class Waf extends constructs.Construct {
+  public readonly webAcl: wafv2.CfnWebACL
+  public readonly webAclArn: string
+  public readonly webAclId: string
+  public logGroup?: logs.LogGroup
+  public logBucket?: s3.Bucket
+  public readonly metric?: cloudwatch.Metric
+
+  constructor(scope: constructs.Construct, id: string, props: WafProps = {}) {
+    super(scope, id)
+
+    const wafScope = props.scope ?? "REGIONAL"
+    const enableMetrics = props.enableMetrics ?? true
+    const enableSampledRequests = props.enableSampledRequests ?? true
+    const defaultAction = props.defaultAction ?? "ALLOW"
+
+    // Convert custom response bodies if provided
+    const customResponseBodies = props.customResponseBodies
+      ? Object.entries(props.customResponseBodies).reduce(
+          (acc, [key, value]) => {
+            acc[key] = {
+              content: value.content,
+              contentType: value.contentType,
+            }
+            return acc
+          },
+          {} as Record<string, any>,
+        )
+      : undefined
+
+    // Build rules array
+    const rules: wafv2.CfnWebACL.RuleProperty[] = []
+
+    // Add managed rule groups
+    if (props.managedRuleGroups) {
+      for (const managedGroup of props.managedRuleGroups) {
+        const rule: wafv2.CfnWebACL.RuleProperty = {
+          name: `ManagedRule-${managedGroup.name}`,
+          priority: managedGroup.priority,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: managedGroup.vendor ?? "AWS",
+              name: managedGroup.name,
+              version: managedGroup.version,
+              excludedRules: managedGroup.excludedRules?.map((ruleName) => ({
+                name: ruleName,
+              })),
+              scopeDownStatement: managedGroup.scopeDownStatement,
+            },
+          },
+          overrideAction: {
+            [managedGroup.overrideAction === "COUNT" ? "count" : "none"]: {},
+          },
+          visibilityConfig: managedGroup.visibilityConfig ?? {
+            sampledRequestsEnabled: enableSampledRequests,
+            cloudWatchMetricsEnabled: enableMetrics,
+            metricName: `ManagedRule-${managedGroup.name.replace(
+              /[^a-zA-Z0-9]/g,
+              "",
+            )}`,
+          },
+        }
+        rules.push(rule)
+      }
+    }
+
+    // Add custom rules
+    if (props.customRules) {
+      for (const customRule of props.customRules) {
+        const rule: wafv2.CfnWebACL.RuleProperty = {
+          name: customRule.name,
+          priority: customRule.priority,
+          statement: customRule.statement,
+          action: this.convertAction(customRule.action),
+          visibilityConfig: customRule.visibilityConfig ?? {
+            sampledRequestsEnabled: enableSampledRequests,
+            cloudWatchMetricsEnabled: enableMetrics,
+            metricName: customRule.name.replace(/[^a-zA-Z0-9]/g, ""),
+          },
+          ruleLabels: customRule.ruleLabels?.map((label) => ({ name: label })),
+          captchaConfig: customRule.captchaConfig,
+          challengeConfig: customRule.challengeConfig,
+        }
+        rules.push(rule)
+      }
+    }
+
+    // Sort rules by priority
+    rules.sort((a, b) => a.priority - b.priority)
+
+    // Create Web ACL
+    this.webAcl = new wafv2.CfnWebACL(this, "WebACL", {
+      scope: wafScope,
+      name: props.name,
+      description: props.description,
+      defaultAction: {
+        [defaultAction.toLowerCase()]: {},
+      },
+      rules,
+      visibilityConfig: {
+        sampledRequestsEnabled: enableSampledRequests,
+        cloudWatchMetricsEnabled: enableMetrics,
+        metricName:
+          props.name?.replace(/[^a-zA-Z0-9]/g, "") ?? `WAF-${this.node.addr}`,
+      },
+      customResponseBodies,
+      tokenDomains: props.tokenDomains,
+      ...props.overrideWebAclProps,
+    })
+
+    this.webAclArn = this.webAcl.attrArn
+    this.webAclId = this.webAcl.attrId
+
+    // Set up logging if enabled
+    if (props.enableLogging) {
+      this.setupLogging(props.logRetention ?? logs.RetentionDays.ONE_WEEK)
+    }
+
+    // Create CloudWatch metric if metrics are enabled
+    if (enableMetrics) {
+      this.metric = new cloudwatch.Metric({
+        namespace: "AWS/WAFV2",
+        metricName: "AllowedRequests",
+        dimensionsMap: {
+          WebACL: this.webAcl.name ?? `WAF-${this.node.addr}`,
+          Rule: "ALL",
+          Region: cdk.Stack.of(this).region,
+        },
+      })
+    }
+  }
+
+  /**
+   * Associate this WAF with a resource (ALB, API Gateway, etc.)
+   */
+  public associateWithResource(resourceArn: string): void {
+    new wafv2.CfnWebACLAssociation(this, "Association", {
+      resourceArn,
+      webAclArn: this.webAclArn,
+    })
+  }
+
+  /**
+   * Add a CloudWatch alarm for blocked requests
+   */
+  public addBlockedRequestsAlarm(
+    threshold: number,
+    evaluationPeriods = 1,
+    datapointsToAlarm = 1,
+  ): cloudwatch.Alarm {
+    return new cloudwatch.Alarm(this, "BlockedRequestsAlarm", {
+      metric: new cloudwatch.Metric({
+        namespace: "AWS/WAFV2",
+        metricName: "BlockedRequests",
+        dimensionsMap: {
+          WebACL: this.webAcl.name ?? `WAF-${this.node.addr}`,
+          Rule: "ALL",
+          Region: cdk.Stack.of(this).region,
+        },
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    })
+  }
+
+  /**
+   * Add a CloudWatch alarm for allowed requests
+   */
+  public addAllowedRequestsAlarm(
+    threshold: number,
+    evaluationPeriods = 1,
+    datapointsToAlarm = 1,
+  ): cloudwatch.Alarm {
+    if (!this.metric) {
+      throw new Error(
+        "Cannot create allowed requests alarm when metrics are disabled",
+      )
+    }
+    return new cloudwatch.Alarm(this, "AllowedRequestsAlarm", {
+      metric: this.metric,
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    })
+  }
+
+  private convertAction(action: string): wafv2.CfnWebACL.RuleActionProperty {
+    switch (action.toUpperCase()) {
+      case "ALLOW":
+        return { allow: {} }
+      case "BLOCK":
+        return { block: {} }
+      case "COUNT":
+        return { count: {} }
+      case "CAPTCHA":
+        return { captcha: {} }
+      case "CHALLENGE":
+        return { challenge: {} }
+      default:
+        return { allow: {} }
+    }
+  }
+
+  private setupLogging(retention: logs.RetentionDays): void {
+    // Create S3 bucket for logs
+    this.logBucket = new s3.Bucket(this, "LogBucket", {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      lifecycleRules: [
+        {
+          expiration: cdk.Duration.days(90),
+        },
+      ],
+    })
+
+    // Create Kinesis Firehose delivery stream
+    const firehoseRole = new iam.Role(this, "FirehoseRole", {
+      assumedBy: new iam.ServicePrincipal("firehose.amazonaws.com"),
+    })
+
+    this.logBucket.grantWrite(firehoseRole)
+
+    const deliveryStream = new kinesisfirehose.CfnDeliveryStream(
+      this,
+      "LogDeliveryStream",
+      {
+        deliveryStreamType: "DirectPut",
+        s3DestinationConfiguration: {
+          bucketArn: this.logBucket.bucketArn,
+          prefix: "waf-logs/",
+          errorOutputPrefix: "error/",
+          compressionFormat: "GZIP",
+          roleArn: firehoseRole.roleArn,
+        },
+      },
+    )
+
+    // Create logging configuration
+    new wafv2.CfnLoggingConfiguration(this, "LoggingConfiguration", {
+      resourceArn: this.webAclArn,
+      logDestinationConfigs: [deliveryStream.attrArn],
+    })
+
+    // Also create CloudWatch Logs group for easier viewing
+    this.logGroup = new logs.LogGroup(this, "LogGroup", {
+      retention,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    })
+  }
+}


### PR DESCRIPTION
### Context

The library was missing support for AWS WAF v2, which is needed for implementing web application firewall protection for ALBs, API Gateways, and CloudFront distributions.

### Description

Add a new AWS WAF v2 construct to the library following existing patterns with:

- Type-safe AWS Managed Rule Groups support (Core Rule Set, Bot Control, SQL injection, etc.)
- Custom rules builder API for common patterns (path blocking, rate limiting, geo-blocking)
- Support for both REGIONAL (ALB/API Gateway) and CLOUDFRONT scopes
- Optional logging to S3 and Kinesis Firehose
- Optional CloudWatch metrics and alarms configuration
- Web ACL association helpers for easy ALB integration
- Comprehensive test suite with snapshot testing
- Proper null coalescing (`??`) throughout for robust error handling

The construct follows existing library conventions with proper Props interfaces, override capabilities, and public readonly properties for integration with other constructs. Both logging and metrics can be independently enabled/disabled, with proper error handling when attempting to use disabled features.

### Testing

- All unit tests pass (12 test cases)
- Snapshot tests capture CloudFormation templates
- Tests cover optional metrics scenarios and error handling
- TypeScript compilation successful
- Linting passes with biome

### Audience

Teams needing WAF protection for their web applications and APIs.

### Scope of impact

This is a new feature that doesn't affect existing consumers. It adds a new `waf` namespace to the library exports.
