### PR TITLE
CALS-1207 Upgrade Python lambda runtimes to 3.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,15 @@ upgrade-dependencies:
 .PHONY: fmt
 fmt:
 	npm run format
+
+.PHONY: lint-python
+lint-python:
+	ruff check
+
+.PHONY: lint-fix-python
+lint-fix-python:
+	ruff check --fix
+
+.PHONY: fmt-python
+fmt-python:
+	ruff format

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ Note: `npm link` cannot be used, since it will lead to multiple
 declarations of the same classes from CDK, breaking the `instanceof`
 operator.
 
+## Verifying Lambda function changes
+
+When updating lambda function runtimes or handler code, we sometimes need to verify that the lambda runs correctly aside from being syntactically correct, such as ensuring imports in handler code are valid for the specified runtime, that required environment variables exist, and so on.
+
+Some specific approaches to validating specific lambda functions in this project:
+
+- `src/alarms/slack-alarm.ts:slackLambda`
+  - Trigger: CloudWatch alarm state change
+  - Inspect: Slack notification
+  - Desc: The function has an associated SNS Topic, which is configured as the action for a CloudWatch Alarm. To verify the function, we manually put the alarm into the ALARM state using the AWS CLI (`aws cloudwatch set-alarm-state --state-value "ALARM" ...`), which posts to the SNS topic and triggers the function. We can then verify that the function executes correctly by checking the Slack channel for the alarm notification, as well as the function logs in CloudWatch.
+- `src/cdk-pipelines/liflig-cdk-pipeline.ts:prepareCdkSourceFn`
+  - Trigger: CodePipeline deployment
+  - Inspect: CloudWatch logs
+  - Desc: This function is triggered by CodePipeline during deployment. To verify the function, we can observe the CodePipeline execution, and inspect the CloudWatch logs of the executed `PrepareCdkSource` step.
+- `src/cdk-pipelines/slack-notification.ts:reportFunction`
+  - Trigger: CodePipeline deployment failure
+  - Inspect: Slack notification, CloudWatch logs
+  - Desc: This function is triggered by CodePipeline during deployment when the pipeline state changes (ok to failed, and so on). To verify the function, we can introduce a failure in the pipeline (for example, by misconfiguring a build step), and observe the Slack notification sent by the function, as well as the function logs in CloudWatch.
+
 ## Contributing
 
 This project accepts contributions. To get started, see the [Contributing Guidelines](./CONTRIBUTING.md).

--- a/__snapshots__/app/cdk-pipeline-cdk-source.template.json
+++ b/__snapshots__/app/cdk-pipeline-cdk-source.template.json
@@ -173,7 +173,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.12",
+        "Runtime": "python3.13",
         "Tags": [
           {
             "Key": "Project",

--- a/assets/cloudtrail-slack-integration-lambda/main.py
+++ b/assets/cloudtrail-slack-integration-lambda/main.py
@@ -51,7 +51,7 @@ def get_slack_payload_for_assume_role_event(event, friendly_names):
     elif principal_id.startswith("AROA"):
         # The other part of the principal ID for a role is the name of the session
         principal_id = principal_id.split(":")[0]
-        pretext_messages.append(f"IAM role")
+        pretext_messages.append("IAM role")
     else:
         pretext_messages.append("principal")
     pretext_messages.append(f"in `{principal_account_id}`")

--- a/assets/pipeline-slack-notification-lambda/index.py
+++ b/assets/pipeline-slack-notification-lambda/index.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import typing as t
 from urllib.error import HTTPError, URLError

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
 [settings]
 idiomatic_version_file_enable_tools = ["node"]
+
+[tools]
+ruff = "0.14.6"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+target-version = "py313"
+include = [
+  "assets/**/*.py",
+  "src/**/*.py"
+]
+
+[lint]
+ignore = ["E722"] # ignore during initial linter introduction

--- a/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
@@ -13,7 +13,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d9fa0c922ce4bc8129ffc5b4336a9215994c76b4b61b0364801d607df00d774b.zip",
+          "S3Key": "b168313d75457e2aed2043426bbb3605e39e368820ee1d491662d7338896f4f3.zip",
         },
         "Description": "Receives CloudWatch Alarms through SNS and sends a formatted version to Slack",
         "Environment": Object {
@@ -53,7 +53,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "python3.11",
+        "Runtime": "python3.13",
         "Timeout": 6,
       },
       "Type": "AWS::Lambda::Function",

--- a/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
@@ -13,7 +13,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b168313d75457e2aed2043426bbb3605e39e368820ee1d491662d7338896f4f3.zip",
+          "S3Key": "d9fa0c922ce4bc8129ffc5b4336a9215994c76b4b61b0364801d607df00d774b.zip",
         },
         "Description": "Receives CloudWatch Alarms through SNS and sends a formatted version to Slack",
         "Environment": Object {

--- a/src/alarms/slack-alarm.ts
+++ b/src/alarms/slack-alarm.ts
@@ -48,7 +48,7 @@ export class SlackAlarm extends constructs.Construct {
         "Receives CloudWatch Alarms through SNS and sends a formatted version to Slack",
       handler: "index.handler",
       memorySize: 128,
-      runtime: lambda.Runtime.PYTHON_3_11,
+      runtime: lambda.Runtime.PYTHON_3_13,
       timeout: Duration.seconds(6),
       environment: {
         SLACK_URL_SECRET_NAME: props.slackWebhookUrlSecret.secretName,

--- a/src/cdk-pipelines/liflig-cdk-pipeline.ts
+++ b/src/cdk-pipelines/liflig-cdk-pipeline.ts
@@ -289,7 +289,7 @@ export class LifligCdkPipeline extends constructs.Construct {
       ),
       handler: "index.handler",
       // Using python instead if NodeJS due to zip-support in stdlib.
-      runtime: lambda.Runtime.PYTHON_3_12,
+      runtime: lambda.Runtime.PYTHON_3_13,
       timeout: cdk.Duration.minutes(1),
       memorySize: 512,
     })

--- a/src/cdk-pipelines/slack-notification.ts
+++ b/src/cdk-pipelines/slack-notification.ts
@@ -79,7 +79,7 @@ export class SlackNotification extends constructs.Construct {
         path.join(__dirname, "../../assets/pipeline-slack-notification-lambda"),
       ),
       handler: "index.handler",
-      runtime: lambda.Runtime.PYTHON_3_11,
+      runtime: lambda.Runtime.PYTHON_3_13,
       timeout: cdk.Duration.seconds(10),
       environment,
       description:

--- a/src/cloudtrail-slack-integration/__tests__/__snapshots__/cloudtrail-slack-integration.test.ts.snap
+++ b/src/cloudtrail-slack-integration/__tests__/__snapshots__/cloudtrail-slack-integration.test.ts.snap
@@ -13,7 +13,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "0c885446d72e6661a79624064ea7cb9e138800f12ba21b79752c0e899c9fb25a.zip",
+          "S3Key": "112c6d5ef2c1f9a71a19198742ea108dbdbe1bbbbfd8ce09743d822fb8b6b50a.zip",
         },
         "Description": "Formats CloudTrail API calls sent through EventBridge, and posts them directly to Slack or first to an SQS FIFO queue for deduplication",
         "Environment": Object {
@@ -31,7 +31,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.13",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -583,7 +583,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "0c885446d72e6661a79624064ea7cb9e138800f12ba21b79752c0e899c9fb25a.zip",
+          "S3Key": "112c6d5ef2c1f9a71a19198742ea108dbdbe1bbbbfd8ce09743d822fb8b6b50a.zip",
         },
         "Description": "Formats CloudTrail API calls sent through EventBridge, and posts them directly to Slack or first to an SQS FIFO queue for deduplication",
         "Environment": Object {
@@ -604,7 +604,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.13",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -1093,7 +1093,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "0c885446d72e6661a79624064ea7cb9e138800f12ba21b79752c0e899c9fb25a.zip",
+          "S3Key": "112c6d5ef2c1f9a71a19198742ea108dbdbe1bbbbfd8ce09743d822fb8b6b50a.zip",
         },
         "Description": "Polls from an SQS FIFO queue containing formatted CloudTrail API calls and sends them to Slack.",
         "Handler": "main.handler_slack_forwarder",
@@ -1103,7 +1103,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.13",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -1337,7 +1337,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "0c885446d72e6661a79624064ea7cb9e138800f12ba21b79752c0e899c9fb25a.zip",
+          "S3Key": "112c6d5ef2c1f9a71a19198742ea108dbdbe1bbbbfd8ce09743d822fb8b6b50a.zip",
         },
         "Description": "Formats CloudTrail API calls sent through EventBridge, and posts them directly to Slack or first to an SQS FIFO queue for deduplication",
         "Environment": Object {
@@ -1358,7 +1358,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.13",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",
@@ -1880,7 +1880,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "0c885446d72e6661a79624064ea7cb9e138800f12ba21b79752c0e899c9fb25a.zip",
+          "S3Key": "112c6d5ef2c1f9a71a19198742ea108dbdbe1bbbbfd8ce09743d822fb8b6b50a.zip",
         },
         "Description": "Polls from an SQS FIFO queue containing formatted CloudTrail API calls and sends them to Slack.",
         "Handler": "main.handler_slack_forwarder",
@@ -1890,7 +1890,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "python3.9",
+        "Runtime": "python3.13",
         "Timeout": 15,
       },
       "Type": "AWS::Lambda::Function",

--- a/src/cloudtrail-slack-integration/cloudtrail-slack-integration.ts
+++ b/src/cloudtrail-slack-integration/cloudtrail-slack-integration.ts
@@ -77,7 +77,7 @@ export class CloudTrailSlackIntegration extends constructs.Construct {
         description:
           "Formats CloudTrail API calls sent through EventBridge, and posts them directly to Slack or first to an SQS FIFO queue for deduplication",
         handler: "main.handler_event_transformer",
-        runtime: lambda.Runtime.PYTHON_3_9,
+        runtime: lambda.Runtime.PYTHON_3_13,
         timeout: cdk.Duration.seconds(15),
         logRetention: logs.RetentionDays.SIX_MONTHS,
         environment: {
@@ -134,7 +134,7 @@ export class CloudTrailSlackIntegration extends constructs.Construct {
         description:
           "Polls from an SQS FIFO queue containing formatted CloudTrail API calls and sends them to Slack.",
         handler: "main.handler_slack_forwarder",
-        runtime: lambda.Runtime.PYTHON_3_9,
+        runtime: lambda.Runtime.PYTHON_3_13,
         timeout: cdk.Duration.seconds(15),
         logRetention: logs.RetentionDays.TWO_WEEKS,
       })


### PR DESCRIPTION
### Context

AWS is deprecating Python 3.9, 3.10 and 3.11 lambda runtimes soon.

Python version | Deprecated | Block function create | Block function update
-- | -- | -- | --
3.9 | Dec 15, 2025 | Feb 3, 2026 | Mar 9, 2026
3.10 | Jun 30, 2026 | Jul 31, 2026 | Aug 31, 2026
3.11 | Jun 30, 2026 | Jul 31, 2026 | Aug 31, 2026
3.12 | Oct 31, 2028 | Nov 30, 2028 | Jan 10, 2029
3.13 | Jun 30, 2029 | Jul 31, 2029 | Aug 31, 2029

### Description

- Introduce Ruff (https://github.com/astral-sh/ruff) as a Python linter
- Upgrade Python lambda runtimes to `python@3.13`. Previous versions:
  - `slack-alarm-lambda`: `3.11`
  - `pipeline-slack-notification-lambda`: `3.11`
  - `prepare-cdk-source-lambda`: `3.12`
  - `cloudtrail-slack-integration-lambda`: `3.9`
- Add new section in `README.md` explaining how to perform manual verification of upgraded lambda functions


### Testing

- [x] Lint (Ruff w/target version 3.13)
- [x] Integrate in existing project and exercise lambdas in AWS
- [x] Review language and runtime changes to look for breakage along upgrade path `v3.9..v3.13`


### Audience

All library consumers

### Scope of impact

All library consumers
