### PR TITLE
fix(rds): add comma to default excluded chars

### DIFF
--- a/src/rds/__tests__/__snapshots__/database.test.ts.snap
+++ b/src/rds/__tests__/__snapshots__/database.test.ts.snap
@@ -73,7 +73,7 @@ Object {
           ],
         },
         "GenerateSecretString": Object {
-          "ExcludeCharacters": " %+~\`#$&*()|[]{}:;<>?!'/@\\"\\\\",
+          "ExcludeCharacters": " %+~\`#$&*()|[]{}:;<>?!'/@\\"\\\\,",
           "GenerateStringKey": "password",
           "PasswordLength": 30,
           "SecretStringTemplate": "{\\"username\\":\\"master\\"}",

--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -7,6 +7,7 @@ import * as rds from "aws-cdk-lib/aws-rds"
 import * as sns from "aws-cdk-lib/aws-sns"
 import "jest-cdk-snapshot"
 import { Database } from ".."
+import { DEFAULT_PASSWORD_EXCLUDE_CHARS } from "../database"
 
 test("create database", () => {
   const app = new App()
@@ -190,6 +191,24 @@ describe("autoMinorVersionUpgrade warning", () => {
     })
     assertions.Annotations.fromStack(stack).hasWarning("*", matcher)
   })
+})
+
+test("local DEFAULT_PASSWORD_EXCLUDE_CHARS tracks aws-cdk's DatabaseSecret default", () => {
+  // Guards against silent drift from aws-cdk-lib's internal default.
+  // If this fails after an aws-cdk-lib bump, reconcile the local constant
+  // with the new upstream value.
+  //
+  // See docstring for DEFAULT_PASSWORD_EXCLUDE_CHARS for upstream link
+  const stack = new Stack(new App(), "Stack")
+  new rds.DatabaseSecret(stack, "Secret", { username: "master" })
+
+  const secrets = assertions.Template.fromStack(stack).findResources(
+    "AWS::SecretsManager::Secret",
+  )
+  const [secret] = Object.values(secrets)
+  expect(secret.Properties.GenerateSecretString.ExcludeCharacters).toBe(
+    DEFAULT_PASSWORD_EXCLUDE_CHARS,
+  )
 })
 
 describe("window validation via overrideDbOptions", () => {

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib"
 import type * as cloudwatch from "aws-cdk-lib/aws-cloudwatch"
 import * as ec2 from "aws-cdk-lib/aws-ec2"
 import * as rds from "aws-cdk-lib/aws-rds"
+import { DEFAULT_PASSWORD_EXCLUDE_CHARS } from "aws-cdk-lib/aws-rds/lib/private/util"
 import type * as sm from "aws-cdk-lib/aws-secretsmanager"
 import * as constructs from "constructs"
 import { DatabaseAlarms } from "../alarms"
@@ -182,6 +183,7 @@ export class Database extends constructs.Construct {
 
     const secret = new rds.DatabaseSecret(this, "Secret", {
       username: masterUsername,
+      excludeCharacters: `${DEFAULT_PASSWORD_EXCLUDE_CHARS},`, // Add comma to default excluded characters
     })
 
     const preferredMaintenanceWindow =

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -171,7 +171,7 @@ export interface DatabaseProps extends cdk.StackProps {
  * These are taken from the default excluded chars in the RdsDatabaseSecret
  * @see https://github.com/aws/aws-cdk/blob/f0b6da82b49da6611f871b67497db8d5004738a2/packages/aws-cdk-lib/aws-rds/lib/private/util.ts#L20
  */
-const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
+export const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
 
 /**
  * Comma is additionally excluded because common env-var configuration

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -173,6 +173,13 @@ export interface DatabaseProps extends cdk.StackProps {
  */
 const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
 
+/**
+ * Comma is additionally excluded because common env-var configuration
+ * libraries (e.g. http4k) treat `,` as a list separator, which causes
+ * failures when a generated password happens to contain a comma.
+ */
+const PASSWORD_EXCLUDE_CHARS = `${DEFAULT_PASSWORD_EXCLUDE_CHARS},`
+
 export class Database extends constructs.Construct {
   public readonly secret: sm.ISecret
   public readonly connections: ec2.Connections
@@ -188,7 +195,7 @@ export class Database extends constructs.Construct {
 
     const secret = new rds.DatabaseSecret(this, "Secret", {
       username: masterUsername,
-      excludeCharacters: `${DEFAULT_PASSWORD_EXCLUDE_CHARS},`, // Add comma to default excluded characters
+      excludeCharacters: PASSWORD_EXCLUDE_CHARS,
     })
 
     const preferredMaintenanceWindow =

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -171,7 +171,7 @@ export interface DatabaseProps extends cdk.StackProps {
  * These are taken from the default excluded chars in the RdsDatabaseSecret
  * @see https://github.com/aws/aws-cdk/blob/f0b6da82b49da6611f871b67497db8d5004738a2/packages/aws-cdk-lib/aws-rds/lib/private/util.ts#L20
  */
-declare const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
+const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
 
 export class Database extends constructs.Construct {
   public readonly secret: sm.ISecret

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -174,11 +174,12 @@ export interface DatabaseProps extends cdk.StackProps {
 export const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
 
 /**
- * Comma is additionally excluded because common env-var configuration
- * libraries (e.g. http4k) treat `,` as a list separator, which causes
- * failures when a generated password happens to contain a comma.
+ * Common env-var configuration libraries (e.g. http4k) treat `,` as a list
+ * separator, which causes failures when a generated password happens to
+ * contain a comma.
  */
-const PASSWORD_EXCLUDE_CHARS = `${DEFAULT_PASSWORD_EXCLUDE_CHARS},`
+const HTTP4K_LIST_SEPARATOR_SYMBOL = ","
+const PASSWORD_EXCLUDE_CHARS = `${DEFAULT_PASSWORD_EXCLUDE_CHARS}${HTTP4K_LIST_SEPARATOR_SYMBOL}`
 
 export class Database extends constructs.Construct {
   public readonly secret: sm.ISecret

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -2,7 +2,6 @@ import * as cdk from "aws-cdk-lib"
 import type * as cloudwatch from "aws-cdk-lib/aws-cloudwatch"
 import * as ec2 from "aws-cdk-lib/aws-ec2"
 import * as rds from "aws-cdk-lib/aws-rds"
-import { DEFAULT_PASSWORD_EXCLUDE_CHARS } from "aws-cdk-lib/aws-rds/lib/private/util"
 import type * as sm from "aws-cdk-lib/aws-secretsmanager"
 import * as constructs from "constructs"
 import { DatabaseAlarms } from "../alarms"
@@ -167,6 +166,12 @@ export interface DatabaseProps extends cdk.StackProps {
    */
   alarms: DatabaseAlarmsConfig
 }
+
+/**
+ * These are taken from the default excluded chars in the RdsDatabaseSecret
+ * @see https://github.com/aws/aws-cdk/blob/f0b6da82b49da6611f871b67497db8d5004738a2/packages/aws-cdk-lib/aws-rds/lib/private/util.ts#L20
+ */
+declare const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
 
 export class Database extends constructs.Construct {
   public readonly secret: sm.ISecret


### PR DESCRIPTION
For contribution guidelines, see `CONTRIBUTING.md`.

### Context

vi har begynt å bruke env vars for å konfigurere tjenester for å dra nytte av en del fordeler dette har for ecs.
når dette ble gjort ble det brukt et http4k bibliotek for å lese og konfigurere med env vars. problemet her er at dette biblioteket ikke helt uten videre "lekte" helt pent med ","(komma) verdier i var-ene (ble parset som liste). ekstra irriterende når man bare fikk en feil når man forsøkte å koble til databasen når man bare har vært "uheldig" i det passordet som ble generert. vi skal ikke trenger å endre for mye bare for ett bibliotek, men tanker er at det ikke er utenkelig at man kan spare seg litt hodebry hvis man fjerner kommaer fra passordene når vi skal konfigurere databasene

### Description

_What are the changes?_

### Testing

_How will the changes be tested?_

### Audience

_Which teams currently needs these changes?_

### Scope of impact

_Which consumers will this change affect?_
