### PR TITLE
feat(rds): disable automatic minor version upgrades by default

### DIFF
--- a/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/slack-alarm.test.ts.snap
@@ -9,12 +9,7 @@ Object {
         "SlackAlarmFunctionServiceRoleC8F1C44C",
       ],
       "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "58d0554bef374568e8bae3560f2115c74abfd6f0b544f908bbd73d09b80a9f46.zip",
-        },
+        "Code": Any<Object>,
         "Description": "Receives CloudWatch Alarms through SNS and sends a formatted version to Slack",
         "Environment": Object {
           "Variables": Object {
@@ -142,12 +137,7 @@ Object {
         "SlackAlarmLogHandlerServiceRole0308E4D8",
       ],
       "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "2bbd1d1041b0a2826e928659aaff9e4aedcd71b59d549427eacb8deaa2692dc8.zip",
-        },
+        "Code": Any<Object>,
         "Description": "Receives CloudWatch Logs subscription events and sends formatted errors to Slack",
         "Environment": Object {
           "Variables": Object {

--- a/src/alarms/__tests__/slack-alarm.test.ts
+++ b/src/alarms/__tests__/slack-alarm.test.ts
@@ -18,5 +18,5 @@ test("create slack alarm", () => {
     slackWebhookUrlSecret: secret,
   })
 
-  expect(stack).toMatchCdkSnapshot()
+  expect(stack).toMatchCdkSnapshot({ ignoreAssets: true })
 })

--- a/src/rds/__tests__/__snapshots__/database.test.ts.snap
+++ b/src/rds/__tests__/__snapshots__/database.test.ts.snap
@@ -8,6 +8,7 @@ Object {
       "Properties": Object {
         "AllocatedStorage": "25",
         "AllowMajorVersionUpgrade": true,
+        "AutoMinorVersionUpgrade": false,
         "BackupRetentionPeriod": 35,
         "CopyTagsToSnapshot": true,
         "DBInstanceClass": "db.t3.micro",

--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -1,5 +1,6 @@
 import "@aws-cdk/assert/jest"
 import { App, Stack } from "aws-cdk-lib"
+import { Annotations } from "aws-cdk-lib/assertions"
 import * as ec2 from "aws-cdk-lib/aws-ec2"
 import * as rds from "aws-cdk-lib/aws-rds"
 import "jest-cdk-snapshot"
@@ -38,6 +39,102 @@ test("create database", () => {
   database.allowConnectionFrom(otherSecurityGroup)
 
   expect(stack).toMatchCdkSnapshot()
+})
+
+test("should disable auto minor version upgrade by default", () => {
+  const app = new App()
+  const stack = new Stack(app, "Stack")
+  const vpc = new ec2.Vpc(stack, "Vpc")
+
+  new Database(stack, "Database", {
+    vpc: vpc,
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: rds.PostgresEngineVersion.VER_12,
+    }),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    instanceIdentifier: "example-database-v1",
+    alarms: { enabled: false },
+  })
+
+  expect(stack).toHaveResourceLike("AWS::RDS::DBInstance", {
+    AutoMinorVersionUpgrade: false,
+  })
+})
+
+test("should allow enabling auto minor version upgrade", () => {
+  const app = new App()
+  const stack = new Stack(app, "Stack")
+  const vpc = new ec2.Vpc(stack, "Vpc")
+
+  new Database(stack, "Database", {
+    vpc: vpc,
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: rds.PostgresEngineVersion.VER_12,
+    }),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    instanceIdentifier: "example-database-v1",
+    autoMinorVersionUpgrade: true,
+    alarms: { enabled: false },
+  })
+
+  expect(stack).toHaveResourceLike("AWS::RDS::DBInstance", {
+    AutoMinorVersionUpgrade: true,
+  })
+})
+
+test("should warn when auto minor version upgrade is enabled without maintenance window", () => {
+  const app = new App()
+  const stack = new Stack(app, "Stack")
+  const vpc = new ec2.Vpc(stack, "Vpc")
+
+  new Database(stack, "Database", {
+    vpc: vpc,
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: rds.PostgresEngineVersion.VER_12,
+    }),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    instanceIdentifier: "example-database-v1",
+    autoMinorVersionUpgrade: true,
+    alarms: { enabled: false },
+  })
+
+  Annotations.fromStack(stack).hasWarning(
+    "/Stack/Database",
+    "Auto minor version upgrade is enabled but no maintenance window is specified. AWS will choose a default maintenance window which may not suit your availability requirements. [ack: @liflig/cdk:autoMinorVersionUpgradeWithoutMaintenanceWindow]",
+  )
+})
+
+test("should not warn when auto minor version upgrade is enabled with maintenance window", () => {
+  const app = new App()
+  const stack = new Stack(app, "Stack")
+  const vpc = new ec2.Vpc(stack, "Vpc")
+
+  new Database(stack, "Database", {
+    vpc: vpc,
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: rds.PostgresEngineVersion.VER_12,
+    }),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    instanceIdentifier: "example-database-v1",
+    autoMinorVersionUpgrade: true,
+    preferredMaintenanceWindow: "sun:03:00-sun:04:00",
+    alarms: { enabled: false },
+  })
+
+  const annotations = Annotations.fromStack(stack)
+  annotations.hasNoWarning("/Stack/Database", "*autoMinorVersionUpgrade*")
 })
 
 test("should set publiclyAccessible also when in private subnets", () => {

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -115,6 +115,25 @@ export interface DatabaseProps extends cdk.StackProps {
    * @default false
    */
   usePublicSubnets?: boolean
+  /**
+   * Whether to enable automatic minor version upgrades for the database engine.
+   *
+   * Note: enabling this means the actual database version may drift from
+   * what is specified in the IaC, as AWS applies upgrades outside of deployments.
+   *
+   * When enabled, consider also setting `preferredMaintenanceWindow`
+   * to control when upgrades are applied.
+   *
+   * @default false
+   */
+  autoMinorVersionUpgrade?: boolean
+  /**
+   * Weekly time range during which system maintenance can occur,
+   * in UTC (e.g. "sun:03:00-sun:04:00").
+   *
+   * If not specified, AWS will choose a default window.
+   */
+  preferredMaintenanceWindow?: string
   overrideDbOptions?: Partial<rds.DatabaseInstanceSourceProps>
   /**
    * Configure database alarms.
@@ -156,6 +175,8 @@ export class Database extends constructs.Construct {
             subnetType: ec2.SubnetType.PUBLIC,
           }
         : undefined,
+      autoMinorVersionUpgrade: props.autoMinorVersionUpgrade ?? false,
+      preferredMaintenanceWindow: props.preferredMaintenanceWindow,
       multiAz: props.isMultiAz ?? true,
       // We default to 25 GiB storage instead of 100 GiB
       // if we do not specify.
@@ -166,6 +187,16 @@ export class Database extends constructs.Construct {
     }
     this.allocatedStorage = cdk.Size.gibibytes(options.allocatedStorage!)
     this.instanceType = options.instanceType!
+
+    if (
+      options.autoMinorVersionUpgrade &&
+      !options.preferredMaintenanceWindow
+    ) {
+      cdk.Annotations.of(this).addWarningV2(
+        "@liflig/cdk:autoMinorVersionUpgradeWithoutMaintenanceWindow",
+        "Auto minor version upgrade is enabled but no maintenance window is specified. AWS will choose a default maintenance window which may not suit your availability requirements.",
+      )
+    }
 
     const db = props.snapshotIdentifier
       ? new rds.DatabaseInstanceFromSnapshot(this, "Resource", {


### PR DESCRIPTION
## Summary
- Disable `autoMinorVersionUpgrade` by default on `Database` construct and expose it as a first-class prop
- Add `preferredMaintenanceWindow` as a first-class prop
- Emit a CDK construct warning when auto upgrades are enabled without a maintenance window
- Fix slack-alarm snapshot test to use `ignoreAssets` to avoid platform-dependent asset hash churn