### PR TITLE
fix: disable ok action by default for errors

### DIFF
--- a/src/alarms/service-alarms.ts
+++ b/src/alarms/service-alarms.ts
@@ -62,8 +62,9 @@ export class ServiceAlarms extends constructs.Construct {
     logGroup: logs.ILogGroup
     alarmDescription?: string
     /**
-     * Set to `false` to stop the alarm from sending OK events.
-     * @default true
+     * Set to `true` to attach OK actions when the alarm returns to OK.
+     * By default OK actions are NOT attached.
+     * @default false
      */
     enableOkAlarm?: boolean
     /**
@@ -102,7 +103,8 @@ export class ServiceAlarms extends constructs.Construct {
       // Default to the warning action
       const actionToUse = props.action ?? this.warningAction
       errorAlarm.addAlarmAction(actionToUse)
-      if (props.enableOkAlarm ?? true) {
+      // By default do NOT attach OK actions for this alarm.
+      if (props.enableOkAlarm ?? false) {
         errorAlarm.addOkAction(actionToUse)
       }
     }

--- a/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
+++ b/src/ecs/__tests__/__snapshots__/fargate-service.test.ts.snap
@@ -136,11 +136,6 @@ Object {
         "EvaluationPeriods": 1,
         "MetricName": "Errors",
         "Namespace": "stack/Stack2/example-service-alarms/Errors",
-        "OKActions": Array [
-          Object {
-            "Ref": "WarningTopicE070F32B",
-          },
-        ],
         "Period": 60,
         "Statistic": "Sum",
         "Threshold": 1,


### PR DESCRIPTION
For contribution guidelines, see `CONTRIBUTING.md`.

### Context

It does not make sense to have an ok action by default after an alarm that informs that there has been an error

