### PR TITLE
revert: remove autoMinorVersionUpgrade default value change

### DIFF
--- a/src/rds/__tests__/__snapshots__/database.test.ts.snap
+++ b/src/rds/__tests__/__snapshots__/database.test.ts.snap
@@ -8,7 +8,6 @@ Object {
       "Properties": Object {
         "AllocatedStorage": "25",
         "AllowMajorVersionUpgrade": true,
-        "AutoMinorVersionUpgrade": false,
         "BackupRetentionPeriod": 35,
         "CopyTagsToSnapshot": true,
         "DBInstanceClass": "db.t3.micro",

--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -1,6 +1,5 @@
 import "@aws-cdk/assert/jest"
 import { App, Stack } from "aws-cdk-lib"
-import { Annotations } from "aws-cdk-lib/assertions"
 import * as ec2 from "aws-cdk-lib/aws-ec2"
 import * as rds from "aws-cdk-lib/aws-rds"
 import "jest-cdk-snapshot"
@@ -39,102 +38,6 @@ test("create database", () => {
   database.allowConnectionFrom(otherSecurityGroup)
 
   expect(stack).toMatchCdkSnapshot()
-})
-
-test("should disable auto minor version upgrade by default", () => {
-  const app = new App()
-  const stack = new Stack(app, "Stack")
-  const vpc = new ec2.Vpc(stack, "Vpc")
-
-  new Database(stack, "Database", {
-    vpc: vpc,
-    engine: rds.DatabaseInstanceEngine.postgres({
-      version: rds.PostgresEngineVersion.VER_12,
-    }),
-    instanceType: ec2.InstanceType.of(
-      ec2.InstanceClass.BURSTABLE3,
-      ec2.InstanceSize.MICRO,
-    ),
-    instanceIdentifier: "example-database-v1",
-    alarms: { enabled: false },
-  })
-
-  expect(stack).toHaveResourceLike("AWS::RDS::DBInstance", {
-    AutoMinorVersionUpgrade: false,
-  })
-})
-
-test("should allow enabling auto minor version upgrade", () => {
-  const app = new App()
-  const stack = new Stack(app, "Stack")
-  const vpc = new ec2.Vpc(stack, "Vpc")
-
-  new Database(stack, "Database", {
-    vpc: vpc,
-    engine: rds.DatabaseInstanceEngine.postgres({
-      version: rds.PostgresEngineVersion.VER_12,
-    }),
-    instanceType: ec2.InstanceType.of(
-      ec2.InstanceClass.BURSTABLE3,
-      ec2.InstanceSize.MICRO,
-    ),
-    instanceIdentifier: "example-database-v1",
-    autoMinorVersionUpgrade: true,
-    alarms: { enabled: false },
-  })
-
-  expect(stack).toHaveResourceLike("AWS::RDS::DBInstance", {
-    AutoMinorVersionUpgrade: true,
-  })
-})
-
-test("should warn when auto minor version upgrade is enabled without maintenance window", () => {
-  const app = new App()
-  const stack = new Stack(app, "Stack")
-  const vpc = new ec2.Vpc(stack, "Vpc")
-
-  new Database(stack, "Database", {
-    vpc: vpc,
-    engine: rds.DatabaseInstanceEngine.postgres({
-      version: rds.PostgresEngineVersion.VER_12,
-    }),
-    instanceType: ec2.InstanceType.of(
-      ec2.InstanceClass.BURSTABLE3,
-      ec2.InstanceSize.MICRO,
-    ),
-    instanceIdentifier: "example-database-v1",
-    autoMinorVersionUpgrade: true,
-    alarms: { enabled: false },
-  })
-
-  Annotations.fromStack(stack).hasWarning(
-    "/Stack/Database",
-    "Auto minor version upgrade is enabled but no maintenance window is specified. AWS will choose a default maintenance window which may not suit your availability requirements. [ack: @liflig/cdk:autoMinorVersionUpgradeWithoutMaintenanceWindow]",
-  )
-})
-
-test("should not warn when auto minor version upgrade is enabled with maintenance window", () => {
-  const app = new App()
-  const stack = new Stack(app, "Stack")
-  const vpc = new ec2.Vpc(stack, "Vpc")
-
-  new Database(stack, "Database", {
-    vpc: vpc,
-    engine: rds.DatabaseInstanceEngine.postgres({
-      version: rds.PostgresEngineVersion.VER_12,
-    }),
-    instanceType: ec2.InstanceType.of(
-      ec2.InstanceClass.BURSTABLE3,
-      ec2.InstanceSize.MICRO,
-    ),
-    instanceIdentifier: "example-database-v1",
-    autoMinorVersionUpgrade: true,
-    preferredMaintenanceWindow: "sun:03:00-sun:04:00",
-    alarms: { enabled: false },
-  })
-
-  const annotations = Annotations.fromStack(stack)
-  annotations.hasNoWarning("/Stack/Database", "*autoMinorVersionUpgrade*")
 })
 
 test("should set publiclyAccessible also when in private subnets", () => {

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -115,25 +115,6 @@ export interface DatabaseProps extends cdk.StackProps {
    * @default false
    */
   usePublicSubnets?: boolean
-  /**
-   * Whether to enable automatic minor version upgrades for the database engine.
-   *
-   * Note: enabling this means the actual database version may drift from
-   * what is specified in the IaC, as AWS applies upgrades outside of deployments.
-   *
-   * When enabled, consider also setting `preferredMaintenanceWindow`
-   * to control when upgrades are applied.
-   *
-   * @default false
-   */
-  autoMinorVersionUpgrade?: boolean
-  /**
-   * Weekly time range during which system maintenance can occur,
-   * in UTC (e.g. "sun:03:00-sun:04:00").
-   *
-   * If not specified, AWS will choose a default window.
-   */
-  preferredMaintenanceWindow?: string
   overrideDbOptions?: Partial<rds.DatabaseInstanceSourceProps>
   /**
    * Configure database alarms.
@@ -175,8 +156,6 @@ export class Database extends constructs.Construct {
             subnetType: ec2.SubnetType.PUBLIC,
           }
         : undefined,
-      autoMinorVersionUpgrade: props.autoMinorVersionUpgrade ?? false,
-      preferredMaintenanceWindow: props.preferredMaintenanceWindow,
       multiAz: props.isMultiAz ?? true,
       // We default to 25 GiB storage instead of 100 GiB
       // if we do not specify.
@@ -187,16 +166,6 @@ export class Database extends constructs.Construct {
     }
     this.allocatedStorage = cdk.Size.gibibytes(options.allocatedStorage!)
     this.instanceType = options.instanceType!
-
-    if (
-      options.autoMinorVersionUpgrade &&
-      !options.preferredMaintenanceWindow
-    ) {
-      cdk.Annotations.of(this).addWarningV2(
-        "@liflig/cdk:autoMinorVersionUpgradeWithoutMaintenanceWindow",
-        "Auto minor version upgrade is enabled but no maintenance window is specified. AWS will choose a default maintenance window which may not suit your availability requirements.",
-      )
-    }
 
     const db = props.snapshotIdentifier
       ? new rds.DatabaseInstanceFromSnapshot(this, "Resource", {


### PR DESCRIPTION
## Summary
- Reverts the default value behaviour change from #406 (`autoMinorVersionUpgrade`, `preferredMaintenanceWindow` props and the construct warning) to allow further discussion on the implementation approach
- Keeps the slack-alarm snapshot fix (`ignoreAssets`) from the same PR