### PR TITLE
fix: regression preventing db storage alarms from being created by default

### DIFF
--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -109,4 +109,3 @@ test("creates storage space and CPU utilization alarms by default when alarms en
     ComparisonOperator: "LessThanThreshold",
   })
 })
-

--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -1,7 +1,9 @@
 import "@aws-cdk/assert/jest"
 import { App, Stack } from "aws-cdk-lib"
+import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions"
 import * as ec2 from "aws-cdk-lib/aws-ec2"
 import * as rds from "aws-cdk-lib/aws-rds"
+import * as sns from "aws-cdk-lib/aws-sns"
 import "jest-cdk-snapshot"
 import { Database } from ".."
 
@@ -67,3 +69,44 @@ test("should set publiclyAccessible also when in private subnets", () => {
     PubliclyAccessible: false,
   })
 })
+
+test("creates storage space and CPU utilization alarms by default when alarms enabled", () => {
+  const app = new App()
+  const supportStack = new Stack(app, "SupportStack")
+  const stack = new Stack(app, "Stack")
+
+  const vpc = new ec2.Vpc(supportStack, "Vpc")
+  const alarmTopic = new sns.Topic(supportStack, "AlarmTopic")
+  const warningTopic = new sns.Topic(supportStack, "WarningTopic")
+
+  new Database(stack, "Database", {
+    vpc: vpc,
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: rds.PostgresEngineVersion.VER_12,
+    }),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    instanceIdentifier: "example-database-v1",
+    snapshotIdentifier: undefined,
+    usePublicSubnets: false,
+    alarms: {
+      alarmAction: new cloudwatchActions.SnsAction(alarmTopic),
+      warningAction: new cloudwatchActions.SnsAction(warningTopic),
+    },
+  })
+
+  // Should have CPU utilization alarm (sent to warnings by default)
+  expect(stack).toHaveResourceLike("AWS::CloudWatch::Alarm", {
+    MetricName: "CPUUtilization",
+    Namespace: "AWS/RDS",
+  })
+
+  // Should have storage space alarms (critically low -> alarms, low -> warnings)
+  expect(stack).toHaveResourceLike("AWS::CloudWatch::Alarm", {
+    MetricName: "FreeStorageSpace",
+    ComparisonOperator: "LessThanThreshold",
+  })
+})
+

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -230,14 +230,9 @@ export class Database extends constructs.Construct {
         })
       }
 
-      if (alarms.storageSpaceAlarms) {
+      if (alarms.storageSpaceAlarms?.enabled !== false) {
         dbAlarms.addStorageSpaceAlarms({
-          enabled: alarms.storageSpaceAlarms.enabled,
-          lowStorageSpaceAlarm: alarms.storageSpaceAlarms.lowStorageSpaceAlarm,
-          criticallyLowStorageSpaceAlarm:
-            alarms.storageSpaceAlarms.criticallyLowStorageSpaceAlarm,
-          appendToAlarmDescription:
-            alarms.storageSpaceAlarms.appendToAlarmDescription,
+          ...alarms.storageSpaceAlarms,
         })
       }
 


### PR DESCRIPTION
### Context

Fix regression introduced preventing storage space alarms from being created by default, and add test to prevent regression from being reintroduced

