### PR TITLE
CALS-1336: RDS window and auto-minor-version-upgrade props

### DIFF
--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -1,5 +1,6 @@
 import "@aws-cdk/assert/jest"
 import { App, Stack } from "aws-cdk-lib"
+import * as assertions from "aws-cdk-lib/assertions"
 import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions"
 import * as ec2 from "aws-cdk-lib/aws-ec2"
 import * as rds from "aws-cdk-lib/aws-rds"
@@ -138,6 +139,58 @@ function synth(opts: {
   })
   return stack
 }
+
+describe("autoMinorVersionUpgrade warning", () => {
+  const matcher = assertions.Match.stringLikeRegexp(
+    "pins a specific minor, but autoMinorVersionUpgrade is true",
+  )
+
+  test("warns when pinned minor + autoMinorVersionUpgrade explicitly true", () => {
+    const stack = synth({
+      version: rds.PostgresEngineVersion.VER_17_5,
+      autoMinorVersionUpgrade: true,
+    })
+    assertions.Annotations.fromStack(stack).hasWarning("*", matcher)
+  })
+
+  test("warns when pinned minor + autoMinorVersionUpgrade defaulted", () => {
+    const stack = synth({ version: rds.PostgresEngineVersion.VER_17_5 })
+    assertions.Annotations.fromStack(stack).hasWarning("*", matcher)
+  })
+
+  test("no warning when pinned minor + autoMinorVersionUpgrade false", () => {
+    const stack = synth({
+      version: rds.PostgresEngineVersion.VER_17_5,
+      autoMinorVersionUpgrade: false,
+    })
+    assertions.Annotations.fromStack(stack).hasNoWarning("*", matcher)
+  })
+
+  test("no warning when major-only version + autoMinorVersionUpgrade true", () => {
+    const stack = synth({
+      version: rds.PostgresEngineVersion.VER_17,
+      autoMinorVersionUpgrade: true,
+    })
+    assertions.Annotations.fromStack(stack).hasNoWarning("*", matcher)
+  })
+
+  test("no warning when overrideDbOptions disables auto-minor-upgrade", () => {
+    const stack = synth({
+      version: rds.PostgresEngineVersion.VER_17_5,
+      overrideDbOptions: { autoMinorVersionUpgrade: false },
+    })
+    assertions.Annotations.fromStack(stack).hasNoWarning("*", matcher)
+  })
+
+  test("overrideDbOptions wins over autoMinorVersionUpgrade prop", () => {
+    const stack = synth({
+      version: rds.PostgresEngineVersion.VER_17_5,
+      autoMinorVersionUpgrade: false,
+      overrideDbOptions: { autoMinorVersionUpgrade: true },
+    })
+    assertions.Annotations.fromStack(stack).hasWarning("*", matcher)
+  })
+})
 
 describe("window validation via overrideDbOptions", () => {
   test("throws when overrideDbOptions windows overlap", () => {

--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -109,3 +109,70 @@ test("creates storage space and CPU utilization alarms by default when alarms en
     ComparisonOperator: "LessThanThreshold",
   })
 })
+
+function synth(opts: {
+  version?: rds.PostgresEngineVersion
+  autoMinorVersionUpgrade?: boolean
+  preferredMaintenanceWindow?: string
+  preferredBackupWindow?: string
+  overrideDbOptions?: Partial<rds.DatabaseInstanceSourceProps>
+}) {
+  const app = new App()
+  const stack = new Stack(app, "Stack")
+  const vpc = new ec2.Vpc(stack, "Vpc")
+  new Database(stack, "Database", {
+    vpc,
+    engine: rds.DatabaseInstanceEngine.postgres({
+      version: opts.version ?? rds.PostgresEngineVersion.VER_17,
+    }),
+    instanceType: ec2.InstanceType.of(
+      ec2.InstanceClass.BURSTABLE3,
+      ec2.InstanceSize.MICRO,
+    ),
+    instanceIdentifier: "example-database-v1",
+    autoMinorVersionUpgrade: opts.autoMinorVersionUpgrade,
+    preferredMaintenanceWindow: opts.preferredMaintenanceWindow,
+    preferredBackupWindow: opts.preferredBackupWindow,
+    overrideDbOptions: opts.overrideDbOptions,
+    alarms: { enabled: false },
+  })
+  return stack
+}
+
+describe("window validation via overrideDbOptions", () => {
+  test("throws when overrideDbOptions windows overlap", () => {
+    expect(() =>
+      synth({
+        overrideDbOptions: {
+          preferredMaintenanceWindow: "sun:03:00-sun:04:00",
+          preferredBackupWindow: "03:30-04:30",
+        },
+      }),
+    ).toThrow(/overlaps/)
+  })
+
+  test("throws when override backup window overlaps typed maintenance window", () => {
+    expect(() =>
+      synth({
+        preferredMaintenanceWindow: "sun:03:00-sun:04:00",
+        overrideDbOptions: { preferredBackupWindow: "03:30-04:30" },
+      }),
+    ).toThrow(/overlaps/)
+  })
+
+  test("throws when override maintenance window is malformed", () => {
+    expect(() =>
+      synth({
+        overrideDbOptions: { preferredMaintenanceWindow: "not-a-window" },
+      }),
+    ).toThrow()
+  })
+
+  test("throws when override backup window is malformed", () => {
+    expect(() =>
+      synth({
+        overrideDbOptions: { preferredBackupWindow: "not-a-window" },
+      }),
+    ).toThrow()
+  })
+})

--- a/src/rds/__tests__/windows.test.ts
+++ b/src/rds/__tests__/windows.test.ts
@@ -1,0 +1,240 @@
+import { overlaps, parseBackupWindow, parseMaintenanceWindow } from "../windows"
+
+describe("parseMaintenanceWindow", () => {
+  const validCases: Array<{ input: string; description: string }> = [
+    { input: "sun:03:00-sun:04:00", description: "same-day 1h window" },
+    { input: "mon:00:00-mon:00:30", description: "minimum 30-min window" },
+    {
+      input: "fri:23:30-sat:00:30",
+      description: "spans midnight (forward-ordered)",
+    },
+    {
+      input: "sun:23:00-mon:02:00",
+      description: "week-boundary wraparound (deferred)",
+    },
+    { input: "mon:00:00-sun:23:30", description: "spans most of the week" },
+    {
+      input: "Thu:03:00-Thu:04:00",
+      description: "capitalized day (AWS accepts this)",
+    },
+    { input: "SUN:03:00-sun:04:00", description: "mixed case across ends" },
+  ]
+
+  test.each(validCases)("accepts $description ($input)", ({ input }) => {
+    expect(() => parseMaintenanceWindow(input)).not.toThrow()
+  })
+
+  const invalidCases: Array<{
+    input: string
+    description: string
+    messageMatches: RegExp
+  }> = [
+    {
+      input: "sun 03:00-sun 04:00",
+      description: "space instead of colon",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "sum:03:00-sun:04:00",
+      description: "unknown day abbreviation",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "sun:3:00-sun:04:00",
+      description: "single-digit hour",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "sun:03:00-sun:04:00:00",
+      description: "extra component",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "",
+      description: "empty string",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "sun:25:00-sun:26:00",
+      description: "hour out of range",
+      messageMatches: /hour must be 0-23/,
+    },
+    {
+      input: "sun:03:60-sun:04:00",
+      description: "minute out of range",
+      messageMatches: /minute must be 0-59/,
+    },
+    {
+      input: "sun:03:00-sun:03:00",
+      description: "zero-length window",
+      messageMatches: /start and end are equal/,
+    },
+    {
+      input: "sun:03:00-sun:03:15",
+      description: "under 30-min minimum (forward)",
+      messageMatches: /minimum is 30/,
+    },
+  ]
+
+  test.each(invalidCases)("rejects $description ($input)", ({
+    input,
+    messageMatches,
+  }) => {
+    expect(() => parseMaintenanceWindow(input)).toThrow(messageMatches)
+  })
+})
+
+describe("parseBackupWindow", () => {
+  const validCases: Array<{ input: string; description: string }> = [
+    { input: "01:00-02:00", description: "same-day 1h window" },
+    { input: "00:00-00:30", description: "minimum 30-min window" },
+    { input: "23:00-01:00", description: "cross-midnight (not rejected)" },
+    { input: "23:59-00:00", description: "end before start (deferred to AWS)" },
+  ]
+
+  test.each(validCases)("accepts $description ($input)", ({ input }) => {
+    expect(() => parseBackupWindow(input)).not.toThrow()
+  })
+
+  const invalidCases: Array<{
+    input: string
+    description: string
+    messageMatches: RegExp
+  }> = [
+    {
+      input: "1:00-2:00",
+      description: "single-digit hour",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "01:00 - 02:00",
+      description: "spaces",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "sun:01:00-sun:02:00",
+      description: "maintenance-style input",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "",
+      description: "empty string",
+      messageMatches: /Expected format/,
+    },
+    {
+      input: "24:00-25:00",
+      description: "hour out of range",
+      messageMatches: /hour must be 0-23/,
+    },
+    {
+      input: "01:60-02:00",
+      description: "minute out of range",
+      messageMatches: /minute must be 0-59/,
+    },
+    {
+      input: "02:00-02:00",
+      description: "zero-length window",
+      messageMatches: /start and end are equal/,
+    },
+    {
+      input: "01:00-01:15",
+      description: "under 30-min minimum (forward)",
+      messageMatches: /minimum is 30/,
+    },
+  ]
+
+  test.each(invalidCases)("rejects $description ($input)", ({
+    input,
+    messageMatches,
+  }) => {
+    expect(() => parseBackupWindow(input)).toThrow(messageMatches)
+  })
+})
+
+describe("overlaps", () => {
+  const cases: Array<{
+    description: string
+    maintenance: string
+    backup: string
+    expected: boolean
+  }> = [
+    {
+      description: "backup contained in maintenance same day",
+      maintenance: "sun:02:00-sun:06:00",
+      backup: "03:00-04:00",
+      expected: true,
+    },
+    {
+      description: "backup partially overlaps maintenance start",
+      maintenance: "sun:03:00-sun:04:00",
+      backup: "02:30-03:30",
+      expected: true,
+    },
+    {
+      description: "backup partially overlaps maintenance end",
+      maintenance: "sun:03:00-sun:04:00",
+      backup: "03:45-04:30",
+      expected: true,
+    },
+    {
+      description: "backup disjoint on same day",
+      maintenance: "sun:03:00-sun:04:00",
+      backup: "05:00-06:00",
+      expected: false,
+    },
+    {
+      description: "backup touches maintenance start (half-open, no overlap)",
+      maintenance: "sun:03:00-sun:04:00",
+      backup: "02:00-03:00",
+      expected: false,
+    },
+    {
+      description: "backup touches maintenance end (half-open, no overlap)",
+      maintenance: "sun:03:00-sun:04:00",
+      backup: "04:00-05:00",
+      expected: false,
+    },
+    {
+      description: "backup overlaps on a different day (daily recurrence)",
+      maintenance: "wed:03:30-wed:04:00",
+      backup: "03:45-04:15",
+      expected: true,
+    },
+    {
+      description: "backup disjoint across all days",
+      maintenance: "wed:10:00-wed:11:00",
+      backup: "03:00-04:00",
+      expected: false,
+    },
+    {
+      description: "maintenance spans midnight, backup overlaps on end day",
+      maintenance: "fri:23:30-sat:00:30",
+      backup: "00:00-00:45",
+      expected: true,
+    },
+    {
+      description: "maintenance spans midnight, backup disjoint on both days",
+      maintenance: "fri:23:30-sat:00:30",
+      backup: "03:00-04:00",
+      expected: false,
+    },
+    {
+      description: "maintenance wraparound treated as non-overlap (deferred)",
+      maintenance: "sat:23:30-sat:00:30",
+      backup: "23:30-00:30",
+      expected: false,
+    },
+    {
+      description: "backup wraparound treated as non-overlap (deferred)",
+      maintenance: "sun:00:00-sun:01:00",
+      backup: "23:00-00:30",
+      expected: false,
+    },
+  ]
+
+  test.each(cases)("$description", ({ maintenance, backup, expected }) => {
+    const mw = parseMaintenanceWindow(maintenance)
+    const bw = parseBackupWindow(backup)
+    expect(overlaps(mw, bw)).toBe(expected)
+  })
+})

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -210,6 +210,15 @@ export class Database extends constructs.Construct {
       parseBackupWindow(preferredBackupWindow)
     }
 
+    warnOnPinnedMinorWithAutoUpgrade(
+      this,
+      props.engine,
+      // AWS default is true.
+      props.overrideDbOptions?.autoMinorVersionUpgrade ??
+        props.autoMinorVersionUpgrade ??
+        true,
+    )
+
     const options: rds.DatabaseInstanceSourceProps = {
       engine: props.engine,
       allowMajorVersionUpgrade: true,
@@ -310,4 +319,20 @@ export class Database extends constructs.Construct {
   public allowConnectionFrom(source: ec2.ISecurityGroup): void {
     this.connections.allowDefaultPortFrom(source)
   }
+}
+
+function warnOnPinnedMinorWithAutoUpgrade(
+  scope: constructs.Construct,
+  engine: rds.IInstanceEngine,
+  autoMinorVersionUpgrade: boolean,
+): void {
+  if (!autoMinorVersionUpgrade) return
+  const version = engine.engineVersion
+  if (!version) return
+  if (version.fullVersion === version.majorVersion) return
+  cdk.Annotations.of(scope).addWarning(
+    `Engine version "${version.fullVersion}" pins a specific minor, but autoMinorVersionUpgrade is true. ` +
+      "AWS may upgrade past this pin during the maintenance window. " +
+      "Either use a major-only version (e.g. PostgresEngineVersion.VER_17) or set autoMinorVersionUpgrade to false.",
+  )
 }

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -5,6 +5,7 @@ import * as rds from "aws-cdk-lib/aws-rds"
 import type * as sm from "aws-cdk-lib/aws-secretsmanager"
 import * as constructs from "constructs"
 import { DatabaseAlarms } from "../alarms"
+import { overlaps, parseBackupWindow, parseMaintenanceWindow } from "./windows"
 
 /**
  * Configure database alarms.
@@ -126,6 +127,33 @@ export interface DatabaseProps extends cdk.StackProps {
    * @default false
    */
   usePublicSubnets?: boolean
+  /**
+   * Weekly maintenance window in UTC, format `ddd:hh:mm-ddd:hh:mm`.
+   * Minimum 30 minutes; must not overlap `preferredBackupWindow`.
+   *
+   * @default AWS-assigned
+   * @example "sun:03:00-sun:04:00"
+   */
+  preferredMaintenanceWindow?: string
+  /**
+   * Daily backup window in UTC, format `hh:mm-hh:mm`.
+   * Minimum 30 minutes; must not overlap `preferredMaintenanceWindow`.
+   *
+   * @default AWS-assigned
+   * @example "01:00-02:00"
+   */
+  preferredBackupWindow?: string
+  /**
+   * Whether AWS automatically applies minor engine version upgrades
+   * during the maintenance window.
+   *
+   * @default AWS default (true)
+   */
+  autoMinorVersionUpgrade?: boolean
+  /**
+   * Escape hatch for RDS option combinations the construct doesn't expose
+   * directly. Overrides any value set via the typed props above.
+   */
   overrideDbOptions?: Partial<rds.DatabaseInstanceSourceProps>
   /**
    * Configure database alarms.
@@ -156,9 +184,38 @@ export class Database extends constructs.Construct {
       username: masterUsername,
     })
 
+    const preferredMaintenanceWindow =
+      props.overrideDbOptions?.preferredMaintenanceWindow ??
+      props.preferredMaintenanceWindow
+    const preferredBackupWindow =
+      props.overrideDbOptions?.preferredBackupWindow ??
+      props.preferredBackupWindow
+
+    if (
+      preferredMaintenanceWindow !== undefined &&
+      preferredBackupWindow !== undefined
+    ) {
+      const mw = parseMaintenanceWindow(preferredMaintenanceWindow)
+      const bw = parseBackupWindow(preferredBackupWindow)
+      if (overlaps(mw, bw)) {
+        throw new Error(
+          `preferredBackupWindow "${preferredBackupWindow}" overlaps ` +
+            `preferredMaintenanceWindow "${preferredMaintenanceWindow}". ` +
+            "AWS requires these windows to be disjoint.",
+        )
+      }
+    } else if (preferredMaintenanceWindow !== undefined) {
+      parseMaintenanceWindow(preferredMaintenanceWindow)
+    } else if (preferredBackupWindow !== undefined) {
+      parseBackupWindow(preferredBackupWindow)
+    }
+
     const options: rds.DatabaseInstanceSourceProps = {
       engine: props.engine,
       allowMajorVersionUpgrade: true,
+      autoMinorVersionUpgrade: props.autoMinorVersionUpgrade,
+      preferredMaintenanceWindow: props.preferredMaintenanceWindow,
+      preferredBackupWindow: props.preferredBackupWindow,
       instanceIdentifier: props.instanceIdentifier,
       instanceType: props.instanceType,
       vpc: props.vpc,

--- a/src/rds/windows.ts
+++ b/src/rds/windows.ts
@@ -1,0 +1,178 @@
+const DAY_NAMES = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const
+type DayName = (typeof DAY_NAMES)[number]
+
+const MIN_WINDOW_MINUTES = 30
+
+const MAINTENANCE_WINDOW_EXAMPLE = "sun:03:00-sun:04:00"
+const BACKUP_WINDOW_EXAMPLE = "01:00-02:00"
+
+// Case-insensitive: AWS accepts "Thu:03:00-Thu:04:00" and "thu:03:00-thu:04:00".
+const MAINTENANCE_WINDOW_REGEX =
+  /^(mon|tue|wed|thu|fri|sat|sun):(\d{2}):(\d{2})-(mon|tue|wed|thu|fri|sat|sun):(\d{2}):(\d{2})$/i
+
+const BACKUP_WINDOW_REGEX = /^(\d{2}):(\d{2})-(\d{2}):(\d{2})$/
+
+export interface ParsedMaintenanceWindow {
+  readonly raw: string
+  readonly startMinuteOfWeek: number
+  readonly endMinuteOfWeek: number
+}
+
+export interface ParsedBackupWindow {
+  readonly raw: string
+  readonly startMinuteOfDay: number
+  readonly endMinuteOfDay: number
+}
+
+export function parseMaintenanceWindow(raw: string): ParsedMaintenanceWindow {
+  const match = MAINTENANCE_WINDOW_REGEX.exec(raw)
+  if (!match) {
+    throw new Error(
+      `Invalid preferredMaintenanceWindow "${raw}". ` +
+        `Expected format ddd:hh:mm-ddd:hh:mm (UTC), e.g. "${MAINTENANCE_WINDOW_EXAMPLE}". ` +
+        `Valid day abbreviations: ${DAY_NAMES.join(", ")}.`,
+    )
+  }
+
+  const [
+    ,
+    startDay,
+    startHourRaw,
+    startMinuteRaw,
+    endDay,
+    endHourRaw,
+    endMinuteRaw,
+  ] = match
+  const startHour = Number(startHourRaw)
+  const startMinute = Number(startMinuteRaw)
+  const endHour = Number(endHourRaw)
+  const endMinute = Number(endMinuteRaw)
+
+  assertHour(startHour, "preferredMaintenanceWindow", raw)
+  assertMinute(startMinute, "preferredMaintenanceWindow", raw)
+  assertHour(endHour, "preferredMaintenanceWindow", raw)
+  assertMinute(endMinute, "preferredMaintenanceWindow", raw)
+
+  const startMinuteOfWeek =
+    dayIndex(startDay.toLowerCase() as DayName) * 24 * 60 +
+    startHour * 60 +
+    startMinute
+  const endMinuteOfWeek =
+    dayIndex(endDay.toLowerCase() as DayName) * 24 * 60 +
+    endHour * 60 +
+    endMinute
+
+  if (startMinuteOfWeek === endMinuteOfWeek) {
+    throw new Error(
+      `Invalid preferredMaintenanceWindow "${raw}": ` +
+        `start and end are equal. Window must be at least ${MIN_WINDOW_MINUTES} minutes. ` +
+        `Example: "${MAINTENANCE_WINDOW_EXAMPLE}".`,
+    )
+  }
+
+  if (
+    endMinuteOfWeek > startMinuteOfWeek &&
+    endMinuteOfWeek - startMinuteOfWeek < MIN_WINDOW_MINUTES
+  ) {
+    throw new Error(
+      `Invalid preferredMaintenanceWindow "${raw}": ` +
+        `window is ${endMinuteOfWeek - startMinuteOfWeek} minutes, minimum is ${MIN_WINDOW_MINUTES}. ` +
+        `Example: "${MAINTENANCE_WINDOW_EXAMPLE}".`,
+    )
+  }
+
+  return { raw, startMinuteOfWeek, endMinuteOfWeek }
+}
+
+export function parseBackupWindow(raw: string): ParsedBackupWindow {
+  const match = BACKUP_WINDOW_REGEX.exec(raw)
+  if (!match) {
+    throw new Error(
+      `Invalid preferredBackupWindow "${raw}". ` +
+        `Expected format hh:mm-hh:mm (UTC), e.g. "${BACKUP_WINDOW_EXAMPLE}".`,
+    )
+  }
+
+  const [, startHourRaw, startMinuteRaw, endHourRaw, endMinuteRaw] = match
+  const startHour = Number(startHourRaw)
+  const startMinute = Number(startMinuteRaw)
+  const endHour = Number(endHourRaw)
+  const endMinute = Number(endMinuteRaw)
+
+  assertHour(startHour, "preferredBackupWindow", raw)
+  assertMinute(startMinute, "preferredBackupWindow", raw)
+  assertHour(endHour, "preferredBackupWindow", raw)
+  assertMinute(endMinute, "preferredBackupWindow", raw)
+
+  const startMinuteOfDay = startHour * 60 + startMinute
+  const endMinuteOfDay = endHour * 60 + endMinute
+
+  if (startMinuteOfDay === endMinuteOfDay) {
+    throw new Error(
+      `Invalid preferredBackupWindow "${raw}": ` +
+        `start and end are equal. Window must be at least ${MIN_WINDOW_MINUTES} minutes. ` +
+        `Example: "${BACKUP_WINDOW_EXAMPLE}".`,
+    )
+  }
+
+  if (
+    endMinuteOfDay > startMinuteOfDay &&
+    endMinuteOfDay - startMinuteOfDay < MIN_WINDOW_MINUTES
+  ) {
+    throw new Error(
+      `Invalid preferredBackupWindow "${raw}": ` +
+        `window is ${endMinuteOfDay - startMinuteOfDay} minutes, minimum is ${MIN_WINDOW_MINUTES}. ` +
+        `Example: "${BACKUP_WINDOW_EXAMPLE}".`,
+    )
+  }
+
+  return { raw, startMinuteOfDay, endMinuteOfDay }
+}
+
+/**
+ * Checks whether the backup and maintenance windows intersect.
+ *
+ * Only considers forward-ordered windows (where end > start). For ambiguous
+ * inputs where end <= start, we defer to AWS's own validation at deploy time
+ * rather than guess whether a wraparound was intended.
+ */
+export function overlaps(
+  mw: ParsedMaintenanceWindow,
+  bw: ParsedBackupWindow,
+): boolean {
+  if (mw.endMinuteOfWeek <= mw.startMinuteOfWeek) return false
+  if (bw.endMinuteOfDay <= bw.startMinuteOfDay) return false
+
+  const minutesPerDay = 24 * 60
+  for (let day = 0; day < 7; day++) {
+    const dayBackupStart = day * minutesPerDay + bw.startMinuteOfDay
+    const dayBackupEnd = day * minutesPerDay + bw.endMinuteOfDay
+    if (
+      dayBackupStart < mw.endMinuteOfWeek &&
+      dayBackupEnd > mw.startMinuteOfWeek
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+function dayIndex(day: DayName): number {
+  return DAY_NAMES.indexOf(day)
+}
+
+function assertHour(hour: number, propName: string, raw: string): void {
+  if (hour > 23) {
+    throw new Error(
+      `Invalid ${propName} "${raw}": hour must be 0-23 (got ${hour}).`,
+    )
+  }
+}
+
+function assertMinute(minute: number, propName: string, raw: string): void {
+  if (minute > 59) {
+    throw new Error(
+      `Invalid ${propName} "${raw}": minute must be 0-59 (got ${minute}).`,
+    )
+  }
+}


### PR DESCRIPTION
Adds three optional props on `Database`:

- `preferredMaintenanceWindow` — weekly UTC window, validated format (`ddd:hh:mm-ddd:hh:mm`, ≥30 min)
- `preferredBackupWindow` — daily UTC window, validated format (`hh:mm-hh:mm`, ≥30 min)
- `autoMinorVersionUpgrade`

Defaults preserve existing behaviour: windows unset → AWS-assigned, `autoMinorVersionUpgrade` unset → AWS default (true, not injected). The `overrideDbOptions` escape hatch still wins over the typed props, and its values are honoured by the window overlap/format validation and by the pinned-minor warning — so customers who already set these via `overrideDbOptions` before the typed props existed get the guardrails too.

A CDK warning is emitted when the engine version pins a specific minor (e.g. `PostgresEngineVersion.VER_17_5`) while `autoMinorVersionUpgrade` is effectively true, since AWS may upgrade past the pin during the maintenance window.

A follow-up PR will make the windows required.