### PR TITLE
feat: add new addTooManyMessagesExistAlarm for SQS queues

### DIFF
--- a/src/alarms/__tests__/__snapshots__/queue-alarms.test.ts.snap
+++ b/src/alarms/__tests__/__snapshots__/queue-alarms.test.ts.snap
@@ -21,11 +21,6 @@ Object {
         "EvaluationPeriods": 1,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
-        "OKActions": Array [
-          Object {
-            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
-          },
-        ],
         "Period": 60,
         "Statistic": "Maximum",
         "Threshold": 60,
@@ -113,6 +108,31 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "QueueAlarmsTooManyMessagesExist500Alarm61A048ED": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "Custom alarm for too many messages",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": "my-queue",
+          },
+        ],
+        "EvaluationPeriods": 2,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 120,
+        "Statistic": "Sum",
+        "Threshold": 500,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
   },
 }
 `;
@@ -138,11 +158,6 @@ Object {
         "EvaluationPeriods": 2,
         "MetricName": "ApproximateAgeOfOldestMessage",
         "Namespace": "AWS/SQS",
-        "OKActions": Array [
-          Object {
-            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
-          },
-        ],
         "Period": 900,
         "Statistic": "Maximum",
         "Threshold": 900,
@@ -225,6 +240,36 @@ Object {
         "Namespace": "AWS/SQS",
         "Period": 300,
         "Statistic": "Minimum",
+        "Threshold": 1,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "QueueAlarmsTooManyMessagesExist1Alarm4678D080": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "AlarmDescription": "my-queue has too many messages (>1)",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": "my-queue",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Fn::ImportValue": "SupportStack:ExportsOutputRefTopicBFC7AF6ECB4A357A",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Sum",
         "Threshold": 1,
         "TreatMissingData": "ignore",
       },

--- a/src/alarms/__tests__/queue-alarms.test.ts
+++ b/src/alarms/__tests__/queue-alarms.test.ts
@@ -22,6 +22,7 @@ test("queue alarms default setup", () => {
 
   alarms.addMessagesNotBeingProcessedAlarm()
   alarms.addApproximateAgeOfOldestMessageAlarm()
+  alarms.addTooManyMessagesExistAlarm({ messageAmountLimit: 1 })
 
   expect(stack).toMatchCdkSnapshot()
 })
@@ -53,6 +54,14 @@ test("queue alarms custom overrides", () => {
     period: cdk.Duration.seconds(60),
     evaluationPeriods: 1,
     thresholdSeconds: 60,
+  })
+
+  alarms.addTooManyMessagesExistAlarm({
+    messageAmountLimit: 500,
+    period: cdk.Duration.seconds(120),
+    evaluationPeriods: 2,
+    enableOkAlarm: false,
+    alarmDescription: "Custom alarm for too many messages",
   })
 
   expect(stack).toMatchCdkSnapshot()

--- a/src/alarms/queue-alarms.ts
+++ b/src/alarms/queue-alarms.ts
@@ -160,7 +160,7 @@ export class QueueAlarms extends constructs.Construct {
      */
     thresholdSeconds?: number
     /**
-     * @default true
+     * @default false
      */
     enableOkAlarm?: boolean
     /** An action to use for CloudWatch alarm state changes instead of the default warningAction */
@@ -198,8 +198,66 @@ export class QueueAlarms extends constructs.Construct {
     // Sent to warnings channel by default
     const action = props?.action ?? this.warningAction
     ageAlarm.addAlarmAction(action)
-    if (props?.enableOkAlarm ?? true) {
+    if (props?.enableOkAlarm) {
       ageAlarm.addOkAction(action)
+    }
+  }
+
+  /**
+   * Alerts when too many messages exist on the queue.
+   */
+  addTooManyMessagesExistAlarm(props: {
+    /**
+     * Maximum number of visible messages before triggering the alarm
+     */
+    messageAmountLimit: number
+    alarmDescription?: string
+    /**
+     * @default cdk.Duration.seconds(300)
+     */
+    period?: cdk.Duration
+    /**
+     * @default 1
+     */
+    evaluationPeriods?: number
+    /**
+     * @default true
+     */
+    enableOkAlarm?: boolean
+    /** An action to use for CloudWatch alarm state changes instead of the default warningAction */
+    action?: IAlarmAction
+  }): void {
+    const period = props.period ?? cdk.Duration.seconds(300)
+    const evaluationPeriods = props.evaluationPeriods ?? 1
+
+    const alarm = new cloudwatch.Metric({
+      metricName: "ApproximateNumberOfMessagesVisible",
+      namespace: "AWS/SQS",
+      statistic: "Sum",
+      period,
+      dimensionsMap: {
+        QueueName: this.queueName,
+      },
+    }).createAlarm(
+      this,
+      `TooManyMessagesExist${props.messageAmountLimit}Alarm`,
+      {
+        alarmDescription:
+          props.alarmDescription ??
+          `${this.queueName} has too many messages (>${props.messageAmountLimit})`,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        evaluationPeriods,
+        threshold: props.messageAmountLimit,
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+      },
+    )
+
+    // Sent to warnings channel by default
+    const action = props.action ?? this.warningAction
+    alarm.addAlarmAction(action)
+    if (props.enableOkAlarm ?? true) {
+      alarm.addOkAction(action)
     }
   }
 }


### PR DESCRIPTION
For contribution guidelines, see `CONTRIBUTING.md`.

### Context

Several projects have a **addTooManyMessagesExistAlarm** alarm, which I originally thought was redundant when we already have an alarm warning about messages not being processed. However, this alarm is useful because teams use it to be alerted when _any_ message shows up on the DLQ.

### Description

New alarm

### Testing

Tested in sandbox account


