### PR TITLE
chore(build): improve build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,6 @@ build: clean install fmt lint-fix npm-build snapshots
 ci: install verify
 
 .PHONY: verify
-# `snapshots-check` pulls in `snapshots` via the dep graph, so a single -j
-# invocation schedules everything correctly: lint, fmt-check, py-test and the
-# snapshots → snapshots-check chain run in parallel.
 verify:
 	@$(MAKE) --no-print-directory -j 4 lint fmt-check snapshots-check py-test
 

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,11 @@ build: clean install fmt lint-fix npm-build snapshots
 ci: install verify
 
 .PHONY: verify
-# Run independent checks in parallel, then ensure snapshots haven't drifted.
-# `snapshots` runs jest with --updateSnapshot; under -j, `npm-cdk-snapshots`
-# is serialized after `npm-jest-snapshots` (see comment there).
+# `snapshots-check` pulls in `snapshots` via the dep graph, so a single -j
+# invocation schedules everything correctly: lint, fmt-check, py-test and the
+# snapshots → snapshots-check chain run in parallel.
 verify:
-	@$(MAKE) --no-print-directory -j 4 lint fmt-check snapshots py-test
-	@$(MAKE) --no-print-directory snapshots-check
+	@$(MAKE) --no-print-directory -j 4 lint fmt-check snapshots-check py-test
 
 
 ######################
@@ -95,7 +94,7 @@ npm-jest-snapshots:
 	npm test -- --updateSnapshot
 
 .PHONY: npm-snapshots-check
-npm-snapshots-check:
+npm-snapshots-check: snapshots
 	git status ':(glob)**/__snapshots__/**' && git add --intent-to-add ':(glob)**/__snapshots__/**' && git diff --exit-code ':(glob)**/__snapshots__/**'
 
 .PHONY: validate-renovate-config

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ all: build
 build: clean install fmt lint-fix npm-build snapshots
 
 .PHONY: ci
-ci: install lint fmt-check npm-build snapshots snapshots-check test
+# `snapshots` runs jest with --updateSnapshot, then `snapshots-check` fails on any drift.
+ci: install lint fmt-check npm-build snapshots snapshots-check py-test
 
 
 ######################
@@ -30,9 +31,6 @@ fmt: npm-fmt py-fmt
 
 .PHONY: fmt-check
 fmt-check: npm-fmt-check py-fmt-check
-
-.PHONY: test
-test: npm-test py-test
 
 .PHONY: snapshots
 snapshots: npm-cdk-snapshots npm-jest-snapshots
@@ -78,9 +76,6 @@ npm-fmt:
 npm-fmt-check:
 	npm run format:check
 
-.PHONY: npm-snapshots
-npm-snapshots: npm-cdk-snapshots npm-jest-snapshots
-
 .PHONY: npm-cdk-snapshots
 npm-cdk-snapshots:
 	npm run snapshots
@@ -96,10 +91,6 @@ npm-snapshots-check:
 .PHONY: validate-renovate-config
 validate-renovate-config:
 	npx --yes --package renovate@latest -- renovate-config-validator --strict renovate.json5
-
-.PHONY: npm-test
-npm-test:
-	npm test
 
 .PHONY: release
 release:

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,15 @@ all: build
 build: clean install fmt lint-fix npm-build snapshots
 
 .PHONY: ci
-# `snapshots` runs jest with --updateSnapshot, then `snapshots-check` fails on any drift.
-ci: install lint fmt-check npm-build snapshots snapshots-check py-test
+ci: install verify
+
+.PHONY: verify
+# Run independent checks in parallel, then ensure snapshots haven't drifted.
+# `snapshots` runs jest with --updateSnapshot; under -j, `npm-cdk-snapshots`
+# is serialized after `npm-jest-snapshots` (see comment there).
+verify:
+	@$(MAKE) --no-print-directory -j 4 lint fmt-check snapshots py-test
+	@$(MAKE) --no-print-directory snapshots-check
 
 
 ######################
@@ -77,7 +84,10 @@ npm-fmt-check:
 	npm run format:check
 
 .PHONY: npm-cdk-snapshots
-npm-cdk-snapshots:
+# Needs `lib/` because create-snapshots.sh runs the compiled cdk-create-snapshots.js.
+# Also serialized after npm-jest-snapshots: both contend on cdk.out, and the CDK CLI's
+# lock blocks jest's in-process synth (Template.fromStack) when they run concurrently.
+npm-cdk-snapshots: npm-build npm-jest-snapshots
 	npm run snapshots
 
 .PHONY: npm-jest-snapshots

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Project commands are defined using `Make`. Examples:
 # Primary commands
 $ make         # runs '$ make build'
 $ make build   # build project, apply lint and formatting fixes, update snapshots
-$ make verify  # verify project, ensure lint, formatting and snapshots are up-to-date
+$ make ci      # verify project, ensure lint, formatting and snapshots are up-to-date
 
 # Misc commands
 $ make lint      # lint code

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Project commands are defined using `Make`. Examples:
 # Primary commands
 $ make         # runs '$ make build'
 $ make build   # build project, apply lint and formatting fixes, update snapshots
-$ make ci      # verify project, ensure lint, formatting and snapshots are up-to-date
+$ make verify  # verify project, ensure lint, formatting and snapshots are up-to-date
 
 # Misc commands
 $ make lint      # lint code

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --enable-source-maps' jest --runInBand",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --enable-source-maps' jest",
     "lint": "biome check",
     "lint:fix": "biome check --fix",
     "format": "biome format --write",

--- a/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
+++ b/src/api-gateway/__tests__/__snapshots__/http-api-gateway.test.ts.snap
@@ -238,7 +238,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "9e1356d2fabae8b3486bc8c6598195c7446bf41e04e671c9d3b8cf95f35f1816.zip",
+          "S3Key": "5fe12bdd7d98c16978923f90c8eb85ca7ac3225738a12e0eba47a6c04ab1111d.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {
@@ -1549,7 +1549,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "9e1356d2fabae8b3486bc8c6598195c7446bf41e04e671c9d3b8cf95f35f1816.zip",
+          "S3Key": "5fe12bdd7d98c16978923f90c8eb85ca7ac3225738a12e0eba47a6c04ab1111d.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {
@@ -2090,7 +2090,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "9e1356d2fabae8b3486bc8c6598195c7446bf41e04e671c9d3b8cf95f35f1816.zip",
+          "S3Key": "5fe12bdd7d98c16978923f90c8eb85ca7ac3225738a12e0eba47a6c04ab1111d.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {
@@ -3051,7 +3051,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "31d4ac456916ac0117e618d98dd200538670c74f9df841e2577814e697c38dca.zip",
+          "S3Key": "5c1741f1dda52bbdff1d6fd5437c9b3d6dcb67560aaa9253227ad06d6a53eab8.zip",
         },
         "Environment": Object {
           "Variables": Object {
@@ -6092,7 +6092,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "9e1356d2fabae8b3486bc8c6598195c7446bf41e04e671c9d3b8cf95f35f1816.zip",
+          "S3Key": "5fe12bdd7d98c16978923f90c8eb85ca7ac3225738a12e0eba47a6c04ab1111d.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {
@@ -7016,7 +7016,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "9e1356d2fabae8b3486bc8c6598195c7446bf41e04e671c9d3b8cf95f35f1816.zip",
+          "S3Key": "5fe12bdd7d98c16978923f90c8eb85ca7ac3225738a12e0eba47a6c04ab1111d.zip",
         },
         "Description": "An authorizer for API-Gateway that checks Basic Auth credentials on requests",
         "Environment": Object {

--- a/src/api-gateway/authorizers/basic-auth-authorizer.ts
+++ b/src/api-gateway/authorizers/basic-auth-authorizer.ts
@@ -36,7 +36,7 @@ export const handler = async (
   event: APIGatewayRequestAuthorizerEventV2,
 ): Promise<AuthorizerResult> => {
   const authHeader = event.headers?.authorization
-  if (!authHeader || !authHeader.startsWith("Basic ")) {
+  if (!authHeader?.startsWith("Basic ")) {
     return { isAuthorized: false }
   }
 

--- a/src/api-gateway/authorizers/cognito-user-pool-authorizer.ts
+++ b/src/api-gateway/authorizers/cognito-user-pool-authorizer.ts
@@ -48,7 +48,7 @@ export const handler = async (
   event: APIGatewayRequestAuthorizerEventV2,
 ): Promise<AuthorizerResult> => {
   const authHeader = event.headers?.authorization
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+  if (!authHeader?.startsWith("Bearer ")) {
     return { isAuthorized: false }
   }
 


### PR DESCRIPTION
Apply some fixes that should cut build time by roughly half.

- Drop `jest --runInBand`; use jest's default worker pool.
- Run lint, fmt-check, snapshots, py-test in parallel via `make verify`.
- Remove redundant second jest run from `make ci`.
- Drop dead Makefile targets (`test`, `npm-test`, `npm-snapshots`).