### PR TITLE
refactor(build-artifacts): return validation errors instead of logging

### DIFF
--- a/src/__tests__/build-artifacts.test.ts
+++ b/src/__tests__/build-artifacts.test.ts
@@ -8,7 +8,7 @@ import {
 import { validateProps as validateGithubActionsRoleProps } from "../build-artifacts/github-actions-role"
 
 test("should fail validation on invalid default branch", () => {
-  const valid = validateBuildArtifactsProps({
+  const errors = validateBuildArtifactsProps({
     bucketName: "my-bucket",
     ecrRepositoryName: "my-ecr-repo",
     githubActions: {
@@ -21,13 +21,13 @@ test("should fail validation on invalid default branch", () => {
       ],
     },
   })
-  expect(valid).toBe(false)
+  expect(errors).toEqual(["Default branch * contains invalid characters"])
 })
 
 test("should fail validation on invalid trusted owner", () => {
   const app = new App()
   const stack = new Stack(app, "Stack")
-  const valid = validateGithubActionsRoleProps({
+  const errors = validateGithubActionsRoleProps({
     oidcProvider: iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
       stack,
       "Provider",
@@ -41,13 +41,13 @@ test("should fail validation on invalid trusted owner", () => {
       },
     ],
   })
-  expect(valid).toBe(false)
+  expect(errors).toContain("Trusted owner * contains invalid characters")
 })
 
 test("should fail validation on missing trusted owner", () => {
   const app = new App()
   const stack = new Stack(app, "Stack")
-  const valid = validateGithubActionsRoleProps({
+  const errors = validateGithubActionsRoleProps({
     oidcProvider: iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
       stack,
       "Provider",
@@ -61,13 +61,15 @@ test("should fail validation on missing trusted owner", () => {
       },
     ],
   })
-  expect(valid).toBe(false)
+  expect(errors).toContain(
+    "Owner capralifecycel of repository my-repository not configured as a trusted owner",
+  )
 })
 
 test("should fail validation on empty list of repositories", () => {
   const app = new App()
   const stack = new Stack(app, "Stack")
-  const valid = validateGithubActionsRoleProps({
+  const errors = validateGithubActionsRoleProps({
     repositories: [],
     oidcProvider: iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
       stack,
@@ -76,13 +78,15 @@ test("should fail validation on empty list of repositories", () => {
     ),
     trustedOwners: ["capralifecycle"],
   })
-  expect(valid).toBe(false)
+  expect(errors).toContain(
+    "At least 1 repository must be supplied, but 0 were given",
+  )
 })
 
 test("should fail validation on empty list of trusted owners", () => {
   const app = new App()
   const stack = new Stack(app, "Stack")
-  const valid = validateGithubActionsRoleProps({
+  const errors = validateGithubActionsRoleProps({
     repositories: [
       {
         name: "my-repository",
@@ -96,7 +100,9 @@ test("should fail validation on empty list of trusted owners", () => {
     ),
     trustedOwners: [],
   })
-  expect(valid).toBe(false)
+  expect(errors).toContain(
+    "At least 1 trusted owner must be supplied, but 0 were given",
+  )
 })
 
 test("should support creation of only 1 role", () => {

--- a/src/build-artifacts/github-actions-role.ts
+++ b/src/build-artifacts/github-actions-role.ts
@@ -58,33 +58,31 @@ export interface Props {
 
 /**
  * Utility function for validating the construct properties.
+ *
+ * Returns a list of validation error messages. An empty list means the props are valid.
  */
-export const validateProps = (props: Props) => {
-  let valid = true
+export const validateProps = (props: Props): string[] => {
+  const errors: string[] = []
   if (props.trustedOwners.length === 0) {
-    console.error("At least 1 trusted owner must be supplied, but 0 were given")
-    valid = false
+    errors.push("At least 1 trusted owner must be supplied, but 0 were given")
   }
   if (props.repositories.length === 0) {
-    console.error("At least 1 repository must be supplied, but 0 were given")
-    valid = false
+    errors.push("At least 1 repository must be supplied, but 0 were given")
   }
   props.trustedOwners.forEach((owner) => {
     if (!owner.match(/^[a-zA-Z0-9-]+$/)) {
-      console.error(`Trusted owner ${owner} contains invalid characters`)
-      valid = false
+      errors.push(`Trusted owner ${owner} contains invalid characters`)
     }
   })
 
   props.repositories.forEach((repository) => {
     if (!props.trustedOwners.includes(repository.owner)) {
-      console.error(
+      errors.push(
         `Owner ${repository.owner} of repository ${repository.name} not configured as a trusted owner`,
       )
-      valid = false
     }
   })
-  return valid
+  return errors
 }
 
 /**
@@ -96,8 +94,9 @@ export class GithubActionsRole extends constructs.Construct {
 
   constructor(scope: constructs.Construct, id: string, props: Props) {
     super(scope, id)
-    if (!validateProps(props)) {
-      throw new Error("Invalid props were supplied")
+    const errors = validateProps(props)
+    if (errors.length > 0) {
+      throw new Error(`Invalid props were supplied: ${errors.join("; ")}`)
     }
 
     const subjects = props.repositories.map(

--- a/src/build-artifacts/index.ts
+++ b/src/build-artifacts/index.ts
@@ -124,19 +124,20 @@ const policyStatements = {
 
 /**
  * Utility function for validating the construct properties.
+ *
+ * Returns a list of validation error messages. An empty list means the props are valid.
  */
-export const validateProps = (props: Props) => {
-  let valid = true
+export const validateProps = (props: Props): string[] => {
+  const errors: string[] = []
   if (
     props.githubActions?.defaultBranch &&
     !props.githubActions.defaultBranch.match(/^[a-zA-Z0-9-]+$/)
   ) {
-    console.error(
+    errors.push(
       `Default branch ${props.githubActions.defaultBranch} contains invalid characters`,
     )
-    valid = false
   }
-  return valid
+  return errors
 }
 
 /**
@@ -162,8 +163,9 @@ export class BuildArtifacts extends constructs.Construct {
   constructor(scope: constructs.Construct, id: string, props: Props) {
     super(scope, id)
 
-    if (!validateProps(props)) {
-      throw new Error("Invalid props were supplied")
+    const errors = validateProps(props)
+    if (errors.length > 0) {
+      throw new Error(`Invalid props were supplied: ${errors.join("; ")}`)
     }
 
     this.bucketName = props.bucketName


### PR DESCRIPTION
## Summary
- `validateProps` returns `string[]` of errors rather than logging via `console.error`
- Constructor joins the errors into the thrown `Error` message
- Removes `console.error` noise from test output; surfaces actual cause to callers

## Notes
- Breaking change to the exported `validateProps` signature (boolean → string[])