### PR TITLE
refactor(ses,cloudtrail-slack): use logGroup instead of deprecated logRetention

### DIFF
--- a/src/cloudtrail-slack-integration/__tests__/__snapshots__/cloudtrail-slack-integration.test.ts.snap
+++ b/src/cloudtrail-slack-integration/__tests__/__snapshots__/cloudtrail-slack-integration.test.ts.snap
@@ -25,6 +25,11 @@ Object {
           },
         },
         "Handler": "main.handler_event_transformer",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "CloudTrailSlackIntegrationEventTransformerLambdaLogGroup747BA2D6",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "CloudTrailSlackIntegrationEventTransformerLambdaServiceRole9B83CFED",
@@ -36,28 +41,13 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CloudTrailSlackIntegrationEventTransformerLambdaLogRetention3FD60AEB": Object {
+    "CloudTrailSlackIntegrationEventTransformerLambdaLogGroup747BA2D6": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "CloudTrailSlackIntegrationEventTransformerLambdaD3A0C95E",
-              },
-            ],
-          ],
-        },
         "RetentionInDays": 180,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
       },
-      "Type": "Custom::LogRetention",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "CloudTrailSlackIntegrationEventTransformerLambdaServiceRole9B83CFED": Object {
       "Properties": Object {
@@ -487,85 +477,6 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
-      "DependsOn": Array [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
-          },
-          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": Array [
-          Object {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
   },
 }
 `;
@@ -598,6 +509,11 @@ Object {
           },
         },
         "Handler": "main.handler_event_transformer",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "CloudTrailSlackIntegrationEventTransformerLambdaLogGroup747BA2D6",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "CloudTrailSlackIntegrationEventTransformerLambdaServiceRole9B83CFED",
@@ -609,28 +525,13 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CloudTrailSlackIntegrationEventTransformerLambdaLogRetention3FD60AEB": Object {
+    "CloudTrailSlackIntegrationEventTransformerLambdaLogGroup747BA2D6": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "CloudTrailSlackIntegrationEventTransformerLambdaD3A0C95E",
-              },
-            ],
-          ],
-        },
         "RetentionInDays": 180,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
       },
-      "Type": "Custom::LogRetention",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "CloudTrailSlackIntegrationEventTransformerLambdaServiceRole9B83CFED": Object {
       "Properties": Object {
@@ -1097,6 +998,11 @@ Object {
         },
         "Description": "Polls from an SQS FIFO queue containing formatted CloudTrail API calls and sends them to Slack.",
         "Handler": "main.handler_slack_forwarder",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "CloudTrailSlackIntegrationSlackForwarderLambdaLogGroup958A35FB",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "CloudTrailSlackIntegrationSlackForwarderLambdaServiceRoleAFAA799A",
@@ -1108,28 +1014,13 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CloudTrailSlackIntegrationSlackForwarderLambdaLogRetention72708236": Object {
+    "CloudTrailSlackIntegrationSlackForwarderLambdaLogGroup958A35FB": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "CloudTrailSlackIntegrationSlackForwarderLambda313A2B40",
-              },
-            ],
-          ],
-        },
         "RetentionInDays": 14,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
       },
-      "Type": "Custom::LogRetention",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "CloudTrailSlackIntegrationSlackForwarderLambdaServiceRoleAFAA799A": Object {
       "Properties": Object {
@@ -1208,85 +1099,6 @@ Object {
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
-      "DependsOn": Array [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
-          },
-          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": Array [
-          Object {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
   },
 }
 `;
@@ -1352,6 +1164,11 @@ Object {
           },
         },
         "Handler": "main.handler_event_transformer",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "CloudTrailSlackIntegrationEventTransformerLambdaLogGroup747BA2D6",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "CloudTrailSlackIntegrationEventTransformerLambdaServiceRole9B83CFED",
@@ -1363,28 +1180,13 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CloudTrailSlackIntegrationEventTransformerLambdaLogRetention3FD60AEB": Object {
+    "CloudTrailSlackIntegrationEventTransformerLambdaLogGroup747BA2D6": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "CloudTrailSlackIntegrationEventTransformerLambdaD3A0C95E",
-              },
-            ],
-          ],
-        },
         "RetentionInDays": 180,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
       },
-      "Type": "Custom::LogRetention",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "CloudTrailSlackIntegrationEventTransformerLambdaServiceRole9B83CFED": Object {
       "Properties": Object {
@@ -1884,6 +1686,11 @@ Object {
         },
         "Description": "Polls from an SQS FIFO queue containing formatted CloudTrail API calls and sends them to Slack.",
         "Handler": "main.handler_slack_forwarder",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "CloudTrailSlackIntegrationSlackForwarderLambdaLogGroup958A35FB",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "CloudTrailSlackIntegrationSlackForwarderLambdaServiceRoleAFAA799A",
@@ -1895,28 +1702,13 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CloudTrailSlackIntegrationSlackForwarderLambdaLogRetention72708236": Object {
+    "CloudTrailSlackIntegrationSlackForwarderLambdaLogGroup958A35FB": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "CloudTrailSlackIntegrationSlackForwarderLambda313A2B40",
-              },
-            ],
-          ],
-        },
         "RetentionInDays": 14,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
       },
-      "Type": "Custom::LogRetention",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "CloudTrailSlackIntegrationSlackForwarderLambdaServiceRoleAFAA799A": Object {
       "Properties": Object {
@@ -1994,85 +1786,6 @@ Object {
         },
       },
       "Type": "AWS::Lambda::EventSourceMapping",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
-      "DependsOn": Array [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
-          },
-          "S3Key": "2819175352ad1ce0dae768e83fc328fb70fb5f10b4a8ff0ccbcb791f02b0716d.zip",
-        },
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": Array [
-          Object {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "TopicBFC7AF6E": Object {
       "Type": "AWS::SNS::Topic",

--- a/src/cloudtrail-slack-integration/cloudtrail-slack-integration.ts
+++ b/src/cloudtrail-slack-integration/cloudtrail-slack-integration.ts
@@ -79,7 +79,9 @@ export class CloudTrailSlackIntegration extends constructs.Construct {
         handler: "main.handler_event_transformer",
         runtime: lambda.Runtime.PYTHON_3_13,
         timeout: cdk.Duration.seconds(15),
-        logRetention: logs.RetentionDays.SIX_MONTHS,
+        logGroup: new logs.LogGroup(this, "EventTransformerLambdaLogGroup", {
+          retention: logs.RetentionDays.SIX_MONTHS,
+        }),
         environment: {
           SLACK_CHANNEL: props.slackChannel,
           DEDUPLICATE_EVENTS: JSON.stringify(!!props.deduplicateEvents),
@@ -136,7 +138,9 @@ export class CloudTrailSlackIntegration extends constructs.Construct {
         handler: "main.handler_slack_forwarder",
         runtime: lambda.Runtime.PYTHON_3_13,
         timeout: cdk.Duration.seconds(15),
-        logRetention: logs.RetentionDays.TWO_WEEKS,
+        logGroup: new logs.LogGroup(this, "SlackForwarderLambdaLogGroup", {
+          retention: logs.RetentionDays.TWO_WEEKS,
+        }),
       })
 
       if (props.infrastructureAlarmAction) {

--- a/src/ses/configurationsetsnsdestination/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/ses/configurationsetsnsdestination/__tests__/__snapshots__/index.test.ts.snap
@@ -3,80 +3,6 @@
 exports[`configuration-set-sns-destination 1`] = `
 Object {
   "Resources": Object {
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
-      "DependsOn": Array [
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-      ],
-      "Properties": Object {
-        "Code": Any<Object>,
-        "Handler": "index.handler",
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:PutRetentionPolicy",
-                "logs:DeleteRetentionPolicy",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
-        "Roles": Array [
-          Object {
-            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "SnsDestinationEventsHandler7DFCB014": Object {
       "DependsOn": Array [
         "SnsDestinationEventsHandlerServiceRole94495B0D",
@@ -84,6 +10,11 @@ Object {
       "Properties": Object {
         "Code": Any<Object>,
         "Handler": "index.handler",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "SnsDestinationEventsHandlerLogGroup64E64CFE",
+          },
+        },
         "Role": Object {
           "Fn::GetAtt": Array [
             "SnsDestinationEventsHandlerServiceRole94495B0D",
@@ -110,28 +41,13 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "SnsDestinationEventsHandlerLogRetention7511E399": Object {
+    "SnsDestinationEventsHandlerLogGroup64E64CFE": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "LogGroupName": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "/aws/lambda/",
-              Object {
-                "Ref": "SnsDestinationEventsHandler7DFCB014",
-              },
-            ],
-          ],
-        },
         "RetentionInDays": 90,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
-            "Arn",
-          ],
-        },
       },
-      "Type": "Custom::LogRetention",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "SnsDestinationEventsHandlerServiceRole94495B0D": Object {
       "Properties": Object {

--- a/src/ses/configurationsetsnsdestination/index.ts
+++ b/src/ses/configurationsetsnsdestination/index.ts
@@ -6,7 +6,7 @@ import * as cdk from "aws-cdk-lib"
 import * as iam from "aws-cdk-lib/aws-iam"
 import * as lambda from "aws-cdk-lib/aws-lambda"
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs"
-import { RetentionDays } from "aws-cdk-lib/aws-logs"
+import * as logs from "aws-cdk-lib/aws-logs"
 import type * as sns from "aws-cdk-lib/aws-sns"
 import * as snsSubscriptions from "aws-cdk-lib/aws-sns-subscriptions"
 import * as cr from "aws-cdk-lib/custom-resources"
@@ -79,7 +79,9 @@ export class ConfigurationSetSnsDestination extends constructs.Construct {
       ),
       handler: "index.handler",
       runtime: lambda.Runtime.NODEJS_24_X,
-      logRetention: RetentionDays.THREE_MONTHS,
+      logGroup: new logs.LogGroup(this, "EventsHandlerLogGroup", {
+        retention: logs.RetentionDays.THREE_MONTHS,
+      }),
     })
 
     if (props.logEvents ?? true) {


### PR DESCRIPTION
## Summary
- Replace deprecated `lambda.FunctionOptions#logRetention` with explicit `logs.LogGroup` resources on three lambdas: `ConfigurationSetSnsDestination/EventsHandler`, `CloudTrailSlackIntegration/EventTransformerLambda`, `CloudTrailSlackIntegration/SlackForwarderLambda`
- Removes the singleton `LogRetention` custom resource (and its Lambda + IAM role) from generated templates
- Tightens function IAM to least-privilege on the new log group

## Consumer impact
On upgrade, `/aws/lambda/<function-name>` becomes orphaned; the lambda writes to a new explicit log group. The orphan keeps its existing retention and ages out to empty. No source-of-truth data is lost — these logs are debug/echo only (CloudTrail / SNS / SQS / Slack hold the underlying events).