### PR TITLE
fix(rds): revert default excluded chars change

### DIFF
--- a/src/rds/__tests__/__snapshots__/database.test.ts.snap
+++ b/src/rds/__tests__/__snapshots__/database.test.ts.snap
@@ -73,7 +73,7 @@ Object {
           ],
         },
         "GenerateSecretString": Object {
-          "ExcludeCharacters": " %+~\`#$&*()|[]{}:;<>?!'/@\\"\\\\,",
+          "ExcludeCharacters": " %+~\`#$&*()|[]{}:;<>?!'/@\\"\\\\",
           "GenerateStringKey": "password",
           "PasswordLength": 30,
           "SecretStringTemplate": "{\\"username\\":\\"master\\"}",

--- a/src/rds/__tests__/database.test.ts
+++ b/src/rds/__tests__/database.test.ts
@@ -7,7 +7,6 @@ import * as rds from "aws-cdk-lib/aws-rds"
 import * as sns from "aws-cdk-lib/aws-sns"
 import "jest-cdk-snapshot"
 import { Database } from ".."
-import { DEFAULT_PASSWORD_EXCLUDE_CHARS } from "../database"
 
 test("create database", () => {
   const app = new App()
@@ -191,24 +190,6 @@ describe("autoMinorVersionUpgrade warning", () => {
     })
     assertions.Annotations.fromStack(stack).hasWarning("*", matcher)
   })
-})
-
-test("local DEFAULT_PASSWORD_EXCLUDE_CHARS tracks aws-cdk's DatabaseSecret default", () => {
-  // Guards against silent drift from aws-cdk-lib's internal default.
-  // If this fails after an aws-cdk-lib bump, reconcile the local constant
-  // with the new upstream value.
-  //
-  // See docstring for DEFAULT_PASSWORD_EXCLUDE_CHARS for upstream link
-  const stack = new Stack(new App(), "Stack")
-  new rds.DatabaseSecret(stack, "Secret", { username: "master" })
-
-  const secrets = assertions.Template.fromStack(stack).findResources(
-    "AWS::SecretsManager::Secret",
-  )
-  const [secret] = Object.values(secrets)
-  expect(secret.Properties.GenerateSecretString.ExcludeCharacters).toBe(
-    DEFAULT_PASSWORD_EXCLUDE_CHARS,
-  )
 })
 
 describe("window validation via overrideDbOptions", () => {

--- a/src/rds/database.ts
+++ b/src/rds/database.ts
@@ -167,20 +167,6 @@ export interface DatabaseProps extends cdk.StackProps {
   alarms: DatabaseAlarmsConfig
 }
 
-/**
- * These are taken from the default excluded chars in the RdsDatabaseSecret
- * @see https://github.com/aws/aws-cdk/blob/f0b6da82b49da6611f871b67497db8d5004738a2/packages/aws-cdk-lib/aws-rds/lib/private/util.ts#L20
- */
-export const DEFAULT_PASSWORD_EXCLUDE_CHARS = " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
-
-/**
- * Common env-var configuration libraries (e.g. http4k) treat `,` as a list
- * separator, which causes failures when a generated password happens to
- * contain a comma.
- */
-const HTTP4K_LIST_SEPARATOR_SYMBOL = ","
-const PASSWORD_EXCLUDE_CHARS = `${DEFAULT_PASSWORD_EXCLUDE_CHARS}${HTTP4K_LIST_SEPARATOR_SYMBOL}`
-
 export class Database extends constructs.Construct {
   public readonly secret: sm.ISecret
   public readonly connections: ec2.Connections
@@ -196,7 +182,6 @@ export class Database extends constructs.Construct {
 
     const secret = new rds.DatabaseSecret(this, "Secret", {
       username: masterUsername,
-      excludeCharacters: PASSWORD_EXCLUDE_CHARS,
     })
 
     const preferredMaintenanceWindow =


### PR DESCRIPTION
Reverts #392.

## Summary
- Restores pre-#392 behaviour
- `excludeCharacters` ends up in in CFN `GenerateSecretString`, which always results in the creation of a new Secret version
- Exclusion behaviour is to be included through a different solution, still up for discussion.