### PR TITLE
ci: fix otel config validation not triggering on PRs

### DIFF
--- a/.github/workflows/validate-otel-config.yml
+++ b/.github/workflows/validate-otel-config.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches:
       - "**"
-    paths:
-      - "src/ecs/open-telemetry.ts"
-      - "assets/open-telemetry/**"
-      - "scripts/validate-otel-config.sh"
-      - ".github/workflows/validate-otel-config.yml"
 
 defaults:
   run:


### PR DESCRIPTION
The `push`+`paths` trigger tied each run to the pushed commit, so a PR whose tip commit did not touch the filtered paths had no run attached to its head SHA and the check never appeared.

Match `ci.yml`: run on push to every branch with no paths filter.