### PR TITLE
fix(ci): pin ruff version to avoid latest picking up new default rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: install python linter
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.14.11"
 
       # Add NEW setup-python step here for any new python version needed for lambda tests
       # We need a separate installation step for each python version because the

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: install python linter
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.14.11"
 
       # Add NEW setup-python step here for any new python version needed for lambda tests
       # We need a separate installation step for each python version because the

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: install python linter
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.14.11"
 
       - name: Build project
         run: make build


### PR DESCRIPTION
ruff-action was resolving to `latest` since no version is declared anywhere in the repo, so it silently jumped to 0.16.0 and started failing on ~30 pre-existing lint findings under rules that became enabled by default. Pin to 0.14.11, the last version known to pass.

For contribution guidelines, see `CONTRIBUTING.md`.

### Context

_Which problem do these changes solve?_

### Description

_What are the changes?_

### Testing

_How will the changes be tested?_

### Audience

_Which teams currently needs these changes?_

### Scope of impact

_Which consumers will this change affect?_
